### PR TITLE
Add support for evaluating aggregate functions

### DIFF
--- a/SelectParser.Tests/ParserExpressionTests.cs
+++ b/SelectParser.Tests/ParserExpressionTests.cs
@@ -550,8 +550,9 @@ namespace SelectParser.Tests
             var result = Parse(Parser.Term, input);
 
             var expression = AssertSuccess(result);
-            var function = Assert.IsType<Expression.FunctionExpression>(expression);
-            var average = Assert.IsType<Function.Aggregate.Average>(function.Function);
+            var function = Assert.IsType<Expression.FunctionExpression>(expression.Value);
+            var aggregate = Assert.IsType<AggregateFunction>(function.Function.Value);
+            var average = Assert.IsType<AggregateFunction.Average>(aggregate.Value);
             AssertIdentifier("Value", average.Expression);
         }
         [Fact]

--- a/SelectParser.Tests/ParserExpressionTests.cs
+++ b/SelectParser.Tests/ParserExpressionTests.cs
@@ -556,6 +556,33 @@ namespace SelectParser.Tests
             AssertIdentifier("Value", average.Expression);
         }
         [Fact]
+        public void ParsingCountColumn()
+        {
+            var input = "COUNT(Value)";
+
+            var result = Parse(Parser.Term, input);
+
+            var expression = AssertSuccess(result);
+            var function = Assert.IsType<Expression.FunctionExpression>(expression.Value);
+            var aggregate = Assert.IsType<AggregateFunction>(function.Function.Value);
+            var count = Assert.IsType<AggregateFunction.Count>(aggregate.Value);
+            Assert.True(count.Expression.IsSome);
+            AssertIdentifier("Value", count.Expression.AsT0);
+        }
+        [Fact]
+        public void ParsingCountStar()
+        {
+            var input = "COUNT(*)";
+
+            var result = Parse(Parser.Term, input);
+
+            var expression = AssertSuccess(result);
+            var function = Assert.IsType<Expression.FunctionExpression>(expression.Value);
+            var aggregate = Assert.IsType<AggregateFunction>(function.Function.Value);
+            var count = Assert.IsType<AggregateFunction.Count>(aggregate.Value);
+            Assert.True(count.Expression.IsNone);
+        }
+        [Fact]
         public void ParsingNumberLiteral()
         {
             var input = "123";

--- a/SelectParser.Tests/ParserExpressionTests.cs
+++ b/SelectParser.Tests/ParserExpressionTests.cs
@@ -480,7 +480,7 @@ namespace SelectParser.Tests
         #endregion
 
         #region Term
-
+        
         [Fact]
         public void ParsingIdentifier()
         {
@@ -541,6 +541,18 @@ namespace SelectParser.Tests
             var qualified = Assert.IsType<Expression.Qualified>(expression.Value);
             Assert.Equal("a", qualified.Qualification.Name);
             AssertIdentifier("*", qualified.Expression);
+        }
+        [Fact]
+        public void ParsingFunction()
+        {
+            var input = "AVG(Value)";
+
+            var result = Parse(Parser.Term, input);
+
+            var expression = AssertSuccess(result);
+            var function = Assert.IsType<Expression.FunctionExpression>(expression);
+            var average = Assert.IsType<Function.Aggregate.Average>(function.Function);
+            AssertIdentifier("Value", average.Expression);
         }
         [Fact]
         public void ParsingNumberLiteral()

--- a/SelectParser/Parser.cs
+++ b/SelectParser/Parser.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using OneOf.Types;
 using SelectParser.Queries;
 using Superpower;
@@ -30,6 +31,28 @@ namespace SelectParser
             Token.Sequence(SelectToken.As, SelectToken.Identifier).Select(x => ParseIdentifier(x[1]).Identifier)
                 .Or(Identifier.Select(x => x.Identifier));
 
+        #region function
+
+        private static readonly TokenListParser<SelectToken, Function> AvgFunction = SingleParameterFunction(SelectToken.Avg, x => new AggregateFunction.Average(x));
+        private static readonly TokenListParser<SelectToken, Function> CountFunction = Token.Sequence(SelectToken.Count, SelectToken.LeftBracket, SelectToken.Star, SelectToken.RightBracket).Select(_ => (Function) (AggregateFunction) new AggregateFunction.Count());
+        private static readonly TokenListParser<SelectToken, Function> MaxFunction = SingleParameterFunction(SelectToken.Max, x => new AggregateFunction.Max(x));
+        private static readonly TokenListParser<SelectToken, Function> MinFunction = SingleParameterFunction(SelectToken.Min, x => new AggregateFunction.Min(x));
+        private static readonly TokenListParser<SelectToken, Function> SumFunction = SingleParameterFunction(SelectToken.Sum, x => new AggregateFunction.Sum(x));
+
+        private static readonly TokenListParser<SelectToken, Function> AggregateFunction = AvgFunction.Or(CountFunction).Or(MaxFunction).Or(MinFunction).Or(SumFunction);
+        private static readonly TokenListParser<SelectToken, Function> Function = AggregateFunction;
+        private static readonly TokenListParser<SelectToken, Expression> FunctionExpression = Function.Select(x => (Expression) new Expression.FunctionExpression(x));
+
+        private static TokenListParser<SelectToken, Function> SingleParameterFunction(SelectToken nameToken, Func<Expression, AggregateFunction> constructor) => SingleParameterFunction(nameToken, x => (Function) constructor(x));
+        private static TokenListParser<SelectToken, Function> SingleParameterFunction(SelectToken nameToken, Func<Expression, Function> constructor) =>
+            from name in Token.EqualTo(nameToken)
+            from begin in Token.EqualTo(SelectToken.LeftBracket)
+            from expr in Parse.Ref(() => Expression)
+            from end in Token.EqualTo(SelectToken.RightBracket)
+            select constructor(expr);
+
+        #endregion
+        
         #region expression 
 
         private static readonly TokenListParser<SelectToken, Expression> QualifiedIdentifier =
@@ -59,6 +82,7 @@ namespace SelectParser
 
         public static readonly TokenListParser<SelectToken, Expression> Term =
             QualifiedIdentifier
+                .Or(FunctionExpression)
                 .Or(Number.Select(x => (Expression)new Expression.NumberLiteral(x)))
                 .Or(String.Select(x => (Expression)new Expression.StringLiteral(x)))
                 .Or(Boolean.Select(x => (Expression)new Expression.BooleanLiteral(x)))

--- a/SelectParser/Parser.cs
+++ b/SelectParser/Parser.cs
@@ -34,11 +34,21 @@ namespace SelectParser
         #region function
 
         private static readonly TokenListParser<SelectToken, Function> AvgFunction = SingleParameterFunction(SelectToken.Avg, x => new AggregateFunction.Average(x));
-        private static readonly TokenListParser<SelectToken, Function> CountFunction = Token.Sequence(SelectToken.Count, SelectToken.LeftBracket, SelectToken.Star, SelectToken.RightBracket).Select(_ => (Function) (AggregateFunction) new AggregateFunction.Count());
+        private static readonly TokenListParser<SelectToken, Function> CountFunction = SingleParameterFunction(SelectToken.Count, BuildCountFunction);
         private static readonly TokenListParser<SelectToken, Function> MaxFunction = SingleParameterFunction(SelectToken.Max, x => new AggregateFunction.Max(x));
         private static readonly TokenListParser<SelectToken, Function> MinFunction = SingleParameterFunction(SelectToken.Min, x => new AggregateFunction.Min(x));
         private static readonly TokenListParser<SelectToken, Function> SumFunction = SingleParameterFunction(SelectToken.Sum, x => new AggregateFunction.Sum(x));
 
+        private static AggregateFunction BuildCountFunction(Expression expression)
+        {
+            if (expression.Value is Expression.Identifier { Name: "*" })
+            {
+                return new AggregateFunction.Count(new None());
+            }
+            
+            return new AggregateFunction.Count(expression);
+        }
+        
         private static readonly TokenListParser<SelectToken, Function> AggregateFunction = AvgFunction.Or(CountFunction).Or(MaxFunction).Or(MinFunction).Or(SumFunction);
         private static readonly TokenListParser<SelectToken, Function> Function = AggregateFunction;
         private static readonly TokenListParser<SelectToken, Expression> FunctionExpression = Function.Select(x => (Expression) new Expression.FunctionExpression(x));

--- a/SelectParser/Queries/Expression.cs
+++ b/SelectParser/Queries/Expression.cs
@@ -6,7 +6,7 @@ using OneOf;
 namespace SelectParser.Queries
 {
     [GenerateOneOf]
-    public partial class Expression : OneOfBase<Expression.StringLiteral, Expression.NumberLiteral, Expression.BooleanLiteral, Expression.Identifier, Expression.Qualified, Expression.Unary, Expression.Binary, Expression.Between, Expression.IsNull, Expression.Presence, Expression.In, Expression.Like>
+    public partial class Expression : OneOfBase<Expression.StringLiteral, Expression.NumberLiteral, Expression.BooleanLiteral, Expression.Identifier, Expression.Qualified, Expression.FunctionExpression, Expression.Unary, Expression.Binary, Expression.Between, Expression.IsNull, Expression.Presence, Expression.In, Expression.Like>
     {
         public override string ToString() => Value.ToString();
 
@@ -177,6 +177,22 @@ namespace SelectParser.Queries
             {
                 return $"{Qualification}.{Expression}";
             }
+        }
+
+        public class FunctionExpression
+        {
+            public Function Function { get; }
+
+            public FunctionExpression(Function function)
+            {
+                Function = function;
+            }
+
+            protected bool Equals(FunctionExpression other) => base.Equals(other) && Function.Equals(other.Function);
+            public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is FunctionExpression other && Equals(other);
+            public override int GetHashCode() { unchecked { return (base.GetHashCode() * 397) ^ Function.GetHashCode(); } }
+
+            public override string ToString() => Function.ToString();
         }
 
         public class Unary

--- a/SelectParser/Queries/Function.cs
+++ b/SelectParser/Queries/Function.cs
@@ -1,0 +1,85 @@
+﻿using OneOf;
+
+namespace SelectParser.Queries
+{
+    public abstract class Function : OneOfBase<Function.Aggregate>
+    {
+        public abstract override string ToString();
+
+        public abstract class Aggregate : OneOfBase<Aggregate.Average, Aggregate.Count, Aggregate.Max, Aggregate.Min, Aggregate.Sum>
+        {
+            public class Average
+            {
+                public Average(Expression expression)
+                {
+                    Expression = expression;
+                }
+
+                public Expression Expression { get; }
+
+                protected bool Equals(Average other) => base.Equals(other) && Expression.Equals(other.Expression);
+                public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Average other && Equals(other);
+                public override int GetHashCode() { unchecked { return (base.GetHashCode() * 397) ^ Expression.GetHashCode(); } }
+
+                public override string ToString() => $"AVG({Expression})";
+            }
+            
+            public class Count
+            {
+                protected bool Equals(Count other) => base.Equals(other);
+                public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Count other && Equals(other);
+                public override int GetHashCode() { unchecked { return base.GetHashCode() * 397; } }
+
+                public override string ToString() => $"COUNT(*)";
+            }
+            
+            public class Max
+            {
+                public Max(Expression expression)
+                {
+                    Expression = expression;
+                }
+
+                public Expression Expression { get; }
+
+                protected bool Equals(Max other) => base.Equals(other) && Expression.Equals(other.Expression);
+                public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Max other && Equals(other);
+                public override int GetHashCode() { unchecked { return (base.GetHashCode() * 397) ^ Expression.GetHashCode(); } }
+
+                public override string ToString() => $"MAX({Expression})";
+            }
+            
+            public class Min
+            {
+                public Min(Expression expression)
+                {
+                    Expression = expression;
+                }
+
+                public Expression Expression { get; }
+
+                protected bool Equals(Min other) => base.Equals(other) && Expression.Equals(other.Expression);
+                public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Min other && Equals(other);
+                public override int GetHashCode() { unchecked { return (base.GetHashCode() * 397) ^ Expression.GetHashCode(); } }
+
+                public override string ToString() => $"MIN({Expression})";
+            }
+           
+            public class Sum
+            {
+                public Sum(Expression expression)
+                {
+                    Expression = expression;
+                }
+
+                public Expression Expression { get; }
+
+                protected bool Equals(Sum other) => base.Equals(other) && Expression.Equals(other.Expression);
+                public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Sum other && Equals(other);
+                public override int GetHashCode() { unchecked { return (base.GetHashCode() * 397) ^ Expression.GetHashCode(); } }
+
+                public override string ToString() => $"SUM({Expression})";
+            }
+        }
+    }
+}

--- a/SelectParser/Queries/Function.cs
+++ b/SelectParser/Queries/Function.cs
@@ -8,7 +8,6 @@ namespace SelectParser.Queries
         public override string ToString() => Value.ToString();
     }
 
-
     [GenerateOneOf]
     public partial class AggregateFunction : OneOfBase<AggregateFunction.Average, AggregateFunction.Count,
         AggregateFunction.Max, AggregateFunction.Min, AggregateFunction.Sum>
@@ -42,7 +41,14 @@ namespace SelectParser.Queries
 
         public class Count
         {
-            protected bool Equals(Count other) => base.Equals(other);
+            public Count(Option<Expression> expression)
+            {
+                Expression = expression;
+            }
+
+            public Option<Expression> Expression { get; }
+
+            protected bool Equals(Count other) => base.Equals(other) && Expression.Equals(other.Expression);
 
             public override bool Equals(object obj) =>
                 ReferenceEquals(this, obj) || obj is Count other && Equals(other);
@@ -51,11 +57,11 @@ namespace SelectParser.Queries
             {
                 unchecked
                 {
-                    return base.GetHashCode() * 397;
+                    return (base.GetHashCode() * 397) ^ Expression.GetHashCode();
                 }
             }
 
-            public override string ToString() => $"COUNT(*)";
+            public override string ToString() => $"COUNT({(Expression.IsSome ? Expression : "*")})";
         }
 
         public class Max

--- a/SelectParser/Queries/Function.cs
+++ b/SelectParser/Queries/Function.cs
@@ -2,84 +2,129 @@
 
 namespace SelectParser.Queries
 {
-    public abstract class Function : OneOfBase<Function.Aggregate>
+    [GenerateOneOf]
+    public partial class Function : OneOfBase<AggregateFunction>
     {
-        public abstract override string ToString();
+        public override string ToString() => Value.ToString();
+    }
 
-        public abstract class Aggregate : OneOfBase<Aggregate.Average, Aggregate.Count, Aggregate.Max, Aggregate.Min, Aggregate.Sum>
+
+    [GenerateOneOf]
+    public partial class AggregateFunction : OneOfBase<AggregateFunction.Average, AggregateFunction.Count,
+        AggregateFunction.Max, AggregateFunction.Min, AggregateFunction.Sum>
+    {
+        public override string ToString() => Value.ToString();
+
+        public class Average
         {
-            public class Average
+            public Average(Expression expression)
             {
-                public Average(Expression expression)
+                Expression = expression;
+            }
+
+            public Expression Expression { get; }
+
+            protected bool Equals(Average other) => base.Equals(other) && Expression.Equals(other.Expression);
+
+            public override bool Equals(object obj) =>
+                ReferenceEquals(this, obj) || obj is Average other && Equals(other);
+
+            public override int GetHashCode()
+            {
+                unchecked
                 {
-                    Expression = expression;
+                    return (base.GetHashCode() * 397) ^ Expression.GetHashCode();
                 }
-
-                public Expression Expression { get; }
-
-                protected bool Equals(Average other) => base.Equals(other) && Expression.Equals(other.Expression);
-                public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Average other && Equals(other);
-                public override int GetHashCode() { unchecked { return (base.GetHashCode() * 397) ^ Expression.GetHashCode(); } }
-
-                public override string ToString() => $"AVG({Expression})";
             }
-            
-            public class Count
-            {
-                protected bool Equals(Count other) => base.Equals(other);
-                public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Count other && Equals(other);
-                public override int GetHashCode() { unchecked { return base.GetHashCode() * 397; } }
 
-                public override string ToString() => $"COUNT(*)";
-            }
-            
-            public class Max
+            public override string ToString() => $"AVG({Expression})";
+        }
+
+        public class Count
+        {
+            protected bool Equals(Count other) => base.Equals(other);
+
+            public override bool Equals(object obj) =>
+                ReferenceEquals(this, obj) || obj is Count other && Equals(other);
+
+            public override int GetHashCode()
             {
-                public Max(Expression expression)
+                unchecked
                 {
-                    Expression = expression;
+                    return base.GetHashCode() * 397;
                 }
-
-                public Expression Expression { get; }
-
-                protected bool Equals(Max other) => base.Equals(other) && Expression.Equals(other.Expression);
-                public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Max other && Equals(other);
-                public override int GetHashCode() { unchecked { return (base.GetHashCode() * 397) ^ Expression.GetHashCode(); } }
-
-                public override string ToString() => $"MAX({Expression})";
             }
-            
-            public class Min
+
+            public override string ToString() => $"COUNT(*)";
+        }
+
+        public class Max
+        {
+            public Max(Expression expression)
             {
-                public Min(Expression expression)
-                {
-                    Expression = expression;
-                }
-
-                public Expression Expression { get; }
-
-                protected bool Equals(Min other) => base.Equals(other) && Expression.Equals(other.Expression);
-                public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Min other && Equals(other);
-                public override int GetHashCode() { unchecked { return (base.GetHashCode() * 397) ^ Expression.GetHashCode(); } }
-
-                public override string ToString() => $"MIN({Expression})";
+                Expression = expression;
             }
-           
-            public class Sum
+
+            public Expression Expression { get; }
+
+            protected bool Equals(Max other) => base.Equals(other) && Expression.Equals(other.Expression);
+            public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Max other && Equals(other);
+
+            public override int GetHashCode()
             {
-                public Sum(Expression expression)
+                unchecked
                 {
-                    Expression = expression;
+                    return (base.GetHashCode() * 397) ^ Expression.GetHashCode();
                 }
-
-                public Expression Expression { get; }
-
-                protected bool Equals(Sum other) => base.Equals(other) && Expression.Equals(other.Expression);
-                public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Sum other && Equals(other);
-                public override int GetHashCode() { unchecked { return (base.GetHashCode() * 397) ^ Expression.GetHashCode(); } }
-
-                public override string ToString() => $"SUM({Expression})";
             }
+
+            public override string ToString() => $"MAX({Expression})";
+        }
+
+        public class Min
+        {
+            public Min(Expression expression)
+            {
+                Expression = expression;
+            }
+
+            public Expression Expression { get; }
+
+            protected bool Equals(Min other) => base.Equals(other) && Expression.Equals(other.Expression);
+            public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Min other && Equals(other);
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (base.GetHashCode() * 397) ^ Expression.GetHashCode();
+                }
+            }
+
+            public override string ToString() => $"MIN({Expression})";
+        }
+
+        public class Sum
+        {
+            public Sum(Expression expression)
+            {
+                Expression = expression;
+            }
+
+            public Expression Expression { get; }
+
+            protected bool Equals(Sum other) => base.Equals(other) && Expression.Equals(other.Expression);
+            public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Sum other && Equals(other);
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (base.GetHashCode() * 397) ^ Expression.GetHashCode();
+                }
+            }
+
+            public override string ToString() => $"SUM({Expression})";
         }
     }
 }

--- a/SelectParser/SelectToken.cs
+++ b/SelectParser/SelectToken.cs
@@ -22,6 +22,12 @@
         Is,
         Missing,
         Null,
+        // functions
+        Avg,
+        Count,
+        Max,
+        Min,
+        Sum,
         // operators
         Dot,
         Comma,

--- a/SelectParser/SelectTokenizer.cs
+++ b/SelectParser/SelectTokenizer.cs
@@ -24,6 +24,12 @@ namespace SelectParser
             { "MISSING", SelectToken.Missing },
             { "NULL", SelectToken.Null },
 
+            { "AVG", SelectToken.Avg },
+            { "COUNT", SelectToken.Count },
+            { "MAX", SelectToken.Max },
+            { "MIN", SelectToken.Min },
+            { "SUM", SelectToken.Sum },
+
             { "TRUE", SelectToken.BooleanLiteral },
             { "FALSE", SelectToken.BooleanLiteral },
 

--- a/SelectQuery.Evaluation.Tests/EvaluatorTests.cs
+++ b/SelectQuery.Evaluation.Tests/EvaluatorTests.cs
@@ -69,6 +69,24 @@ namespace SelectQuery.Evaluation.Tests
             Assert.Equal(expectedCount, response.Count(x => x == '\n'));
         }
 
+        [Theory]
+
+        [InlineData("SELECT AVG(a) FROM s3object", @"{""_1"":10}")]
+        [InlineData("SELECT COUNT(*) FROM s3object", @"{""_1"":5}")]
+        [InlineData("SELECT MAX(a) FROM s3object", @"{""_1"":15}")]
+        [InlineData("SELECT MIN(a) FROM s3object", @"{""_1"":5}")]
+        [InlineData("SELECT SUM(a) FROM s3object", @"{""_1"":30}")]
+        public void AggregateQueries(string queryString, string expectedRecord)
+        {
+            var query = ParseQuery(queryString);
+            var data = new [] { @"{""a"": 5}", @"{""a"": 10}", @"{""a"": 15}", @"{}", @"{""b"": 5}" };
+            var expectedResponse = new[] {expectedRecord};
+
+            var response = Evaluate(query, data);
+
+            AssertResponse(expectedResponse, response);
+        }
+        
         private static Query ParseQuery(string query)
         {
             var tokens = new SelectTokenizer().Tokenize(query);

--- a/SelectQuery.Evaluation.Tests/EvaluatorTests.cs
+++ b/SelectQuery.Evaluation.Tests/EvaluatorTests.cs
@@ -71,16 +71,24 @@ namespace SelectQuery.Evaluation.Tests
 
         [Theory]
 
-        [InlineData("SELECT AVG(s.a) FROM s3object s", @"{""_1"":10}")]
-        [InlineData("SELECT COUNT(*) FROM s3object s", @"{""_1"":5}")]
-        [InlineData("SELECT COUNT(s.a) FROM s3object s", @"{""_1"":3}")]
-        [InlineData("SELECT MAX(s.a) FROM s3object s", @"{""_1"":15}")]
-        [InlineData("SELECT MIN(s.a) FROM s3object s", @"{""_1"":5}")]
-        [InlineData("SELECT SUM(s.a) FROM s3object s", @"{""_1"":30}")]
-        public void AggregateQueries(string queryString, string expectedRecord)
+        [InlineData("SELECT AVG(s.a) FROM s3object s", true, @"{""_1"":10}")]
+        [InlineData("SELECT AVG(s.a) FROM s3object s", false, @"{""_1"":null}")]
+        [InlineData("SELECT COUNT(*) FROM s3object s", true, @"{""_1"":5}")]
+        [InlineData("SELECT COUNT(*) FROM s3object s", false, @"{""_1"":0}")]
+        [InlineData("SELECT COUNT(s.a) FROM s3object s", true, @"{""_1"":3}")]
+        [InlineData("SELECT COUNT(s.a) FROM s3object s", false, @"{""_1"":0}")]
+        [InlineData("SELECT MAX(s.a) FROM s3object s", true, @"{""_1"":15}")]
+        [InlineData("SELECT MAX(s.a) FROM s3object s", false, @"{""_1"":null}")]
+        [InlineData("SELECT MIN(s.a) FROM s3object s", true, @"{""_1"":5}")]
+        [InlineData("SELECT MIN(s.a) FROM s3object s", false, @"{""_1"":null}")]
+        [InlineData("SELECT SUM(s.a) FROM s3object s", true, @"{""_1"":30}")]
+        [InlineData("SELECT SUM(s.a) FROM s3object s", false, @"{""_1"":null}")]
+        [InlineData("SELECT MAX(s.a), COUNT(*) as NumOfItems, SUM(s.a) FROM s3object s", true, @"{""_1"":15,""NumOfItems"":5,""_3"":30}")]
+        [InlineData("SELECT MAX(s.a), COUNT(*) as NumOfItems, SUM(s.a) FROM s3object s", false, @"{""_1"":null,""NumOfItems"":0,""_3"":null}")]
+        public void AggregateQueries(string queryString, bool withData, string expectedRecord)
         {
             var query = ParseQuery(queryString);
-            var data = new [] { @"{""a"": 5}", @"{""a"": 10}", @"{""a"": 15}", @"{}", @"{""b"": 5}" };
+            var data = withData ? new [] { @"{""a"": 5}", @"{""a"": 10}", @"{""a"": 15}", @"{}", @"{""b"": 5}" } : new string[] { };
             var expectedResponse = new[] {expectedRecord};
 
             var response = Evaluate(query, data);

--- a/SelectQuery.Evaluation.Tests/EvaluatorTests.cs
+++ b/SelectQuery.Evaluation.Tests/EvaluatorTests.cs
@@ -71,11 +71,12 @@ namespace SelectQuery.Evaluation.Tests
 
         [Theory]
 
-        [InlineData("SELECT AVG(a) FROM s3object", @"{""_1"":10}")]
-        [InlineData("SELECT COUNT(*) FROM s3object", @"{""_1"":5}")]
-        [InlineData("SELECT MAX(a) FROM s3object", @"{""_1"":15}")]
-        [InlineData("SELECT MIN(a) FROM s3object", @"{""_1"":5}")]
-        [InlineData("SELECT SUM(a) FROM s3object", @"{""_1"":30}")]
+        [InlineData("SELECT AVG(s.a) FROM s3object s", @"{""_1"":10}")]
+        [InlineData("SELECT COUNT(*) FROM s3object s", @"{""_1"":5}")]
+        [InlineData("SELECT COUNT(s.a) FROM s3object s", @"{""_1"":3}")]
+        [InlineData("SELECT MAX(s.a) FROM s3object s", @"{""_1"":15}")]
+        [InlineData("SELECT MIN(s.a) FROM s3object s", @"{""_1"":5}")]
+        [InlineData("SELECT SUM(s.a) FROM s3object s", @"{""_1"":30}")]
         public void AggregateQueries(string queryString, string expectedRecord)
         {
             var query = ParseQuery(queryString);

--- a/SelectQuery.Evaluation/AggregateProcessor.cs
+++ b/SelectQuery.Evaluation/AggregateProcessor.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using SelectParser;
+using SelectParser.Queries;
+using Utf8Json;
+
+namespace SelectQuery.Evaluation;
+
+internal class AggregateProcessor
+{
+    private static readonly ExpressionEvaluator ExpressionEvaluator = new();
+
+    private readonly IReadOnlyList<ColumnState> _columns;
+
+    public AggregateProcessor(Query query)
+    {
+        _columns = ColumnState.CreateForQuery(query);
+    }
+
+    public void ProcessRecord(object record)
+    {
+        foreach (var column in _columns)
+        {
+            column.ProcessRecord(record);
+        }
+    }
+
+    public void Write(ref JsonWriter writer)
+    {
+        writer.WriteBeginObject();
+     
+        var hasWritten = false;
+        for (var index = 0; index < _columns.Count; index++)
+        {
+            if (hasWritten)
+            {
+                writer.WriteValueSeparator();
+            }
+            hasWritten = true;
+            
+            var columnState = _columns[index];
+            
+            writer.WritePropertyName(JsonRecordWriter.GetColumnName(index, columnState.Column));
+            columnState.WriteResult(ref writer);
+        }
+
+        writer.WriteEndObject();
+    }
+    
+    private abstract class ColumnState
+    {
+        private readonly Query _query;
+        public Column Column { get; }
+
+        protected ColumnState(Column column, Query query)
+        {
+            _query = query;
+            Column = column;
+        }
+
+        public static IReadOnlyList<ColumnState> CreateForQuery(Query query)
+        {
+            var states = new List<ColumnState>();
+
+            var columns = query.Select.AsT1.Columns;
+            foreach (var column in columns)
+            {
+                states.Add(CreateForColumn(query, column));
+            }
+                        
+            return states;
+        }
+
+        private static ColumnState CreateForColumn(Query query, Column column)
+        {
+            if (!(column.Expression.Value is Expression.FunctionExpression functionExpression))
+            {
+                throw new NotImplementedException();
+            }
+
+            if (!(functionExpression.Function.Value is AggregateFunction aggregateFunction))
+            {
+                throw new NotImplementedException();
+            }
+
+            return aggregateFunction.Match<ColumnState>(
+                x => new AverageColumnState(column, query, x),                
+                x => new CountColumnState(column, query, x),                
+                x => new MaxColumnState(column, query, x),                
+                x => new MinColumnState(column, query, x),                
+                x => new SumColumnState(column, query, x)                
+            );
+        }
+        
+        public abstract void ProcessRecord(object record);
+        public abstract void WriteResult(ref JsonWriter writer);
+
+        protected Option<T> Evaluate<T>(Expression expression, object record) => ExpressionEvaluator.EvaluateOnTable<T>(expression, _query.From, record);
+
+        private class AverageColumnState : ColumnState
+        {
+            private readonly AggregateFunction.Average _average;
+            private int _count;
+            private decimal _acc;
+            
+            public AverageColumnState(Column column, Query query, AggregateFunction.Average average) : base(column, query) => _average = average;
+
+            public override void ProcessRecord(object record)
+            {
+                var value = Evaluate<object>(_average.Expression, record);
+                if (value.IsNone)
+                {
+                    return;
+                }
+                
+                _count++;
+                _acc += (decimal) value.AsT0;
+            }
+
+            public override void WriteResult(ref JsonWriter writer)
+            {
+                if (_count > 0)
+                {
+                    var result = _acc / _count;
+
+                    writer.WriteDouble((double)result);
+                }
+                else
+                {
+                    writer.WriteNull();
+                }
+            }
+        }
+        
+        private class CountColumnState : ColumnState
+        {
+            private readonly AggregateFunction.Count _count;
+            private int _acc;
+            
+            public CountColumnState(Column column, Query query, AggregateFunction.Count count) : base(column, query) => _count = count;
+            
+            public override void ProcessRecord(object record)
+            {
+                if (!_count.Expression.IsNone)
+                {
+                    var value = Evaluate<object>(_count.Expression.AsT0, record);
+                    if (value.IsNone)
+                    {
+                        return;
+                    }
+                }
+
+                _acc++;
+            }
+
+            public override void WriteResult(ref JsonWriter writer)
+            {
+                writer.WriteInt32(_acc);
+            }
+        }
+        
+        private class MaxColumnState : ColumnState
+        {
+            private readonly AggregateFunction.Max _max;
+            private decimal? _best;
+            
+            public MaxColumnState(Column column, Query query, AggregateFunction.Max max) : base(column, query) => _max = max;
+            
+            public override void ProcessRecord(object record)
+            {
+                var result = Evaluate<object>(_max.Expression, record);
+                if (result.IsNone)
+                {
+                    return;
+                }
+                
+                var value = (decimal) result.AsT0;
+                if (_best == null || value > _best)
+                {
+                    _best = value;
+                }
+            }
+
+            public override void WriteResult(ref JsonWriter writer)
+            {
+                if (_best != null)
+                {
+                    writer.WriteDouble((double)_best);
+                }
+                else
+                {
+                    writer.WriteNull();
+                }
+            }
+        }
+        
+        private class MinColumnState : ColumnState
+        {
+            private readonly AggregateFunction.Min _min;
+            private decimal? _best;
+
+            public MinColumnState(Column column, Query query, AggregateFunction.Min min) : base(column, query) => _min = min;
+            
+            public override void ProcessRecord(object record)
+            {
+                var result = Evaluate<object>(_min.Expression, record);
+                if (result.IsNone)
+                {
+                    return;
+                }
+                
+                var value = (decimal) result.AsT0;
+                if (_best == null || value < _best)
+                {
+                    _best = value;
+                }
+            }
+
+            public override void WriteResult(ref JsonWriter writer)
+            {
+                if (_best != null)
+                {
+                    writer.WriteDouble((double)_best);
+                }
+                else
+                {
+                    writer.WriteNull();
+                }
+            }
+        }
+        
+        private class SumColumnState : ColumnState
+        {
+            private readonly AggregateFunction.Sum _sum;
+            private decimal? _acc;
+            
+            public SumColumnState(Column column, Query query, AggregateFunction.Sum sum) : base(column, query) => _sum = sum;
+            
+            public override void ProcessRecord(object record)
+            {
+                var value = Evaluate<object>(_sum.Expression, record);
+                if (value.IsNone)
+                {
+                    return;
+                }
+                
+                _acc = (_acc ?? 0) + (decimal) value.AsT0;
+            }
+
+            public override void WriteResult(ref JsonWriter writer)
+            {
+                if (_acc != null)
+                {
+                    writer.WriteDouble((double)_acc);
+                }
+                else
+                {
+                    writer.WriteNull();
+                }
+            }
+        }
+    }
+}

--- a/SelectQuery.Evaluation/ExpressionEvaluator.cs
+++ b/SelectQuery.Evaluation/ExpressionEvaluator.cs
@@ -17,6 +17,7 @@ namespace SelectQuery.Evaluation
                 boolLiteral => (T)(object)EvaluateBooleanLiteral(boolLiteral),
                 identifier => EvaluateIdentifier<T>(identifier, obj),
                 qualified => EvaluateQualified<T>(qualified, obj),
+                function => throw new NotImplementedException(),
                 unary => EvaluateUnary<T>(unary, obj),
                 binary => EvaluateBinary<T>(binary, obj),
                 between => (T)(object)EvaluateBetween(between, obj),

--- a/SelectQuery.Evaluation/JsonLinesEvaluator.cs
+++ b/SelectQuery.Evaluation/JsonLinesEvaluator.cs
@@ -1,4 +1,6 @@
-﻿using SelectParser.Queries;
+﻿using OneOf.Types;
+using SelectParser;
+using SelectParser.Queries;
 using Utf8Json;
 using Utf8Json.Resolvers;
 
@@ -27,29 +29,75 @@ namespace SelectQuery.Evaluation
             var reader = new JsonReader(file);
             var writer = new JsonWriter();
 
-            while (ProcessRecord(ref reader, ref writer)) { }
+            if (QueryValidator.IsAggregateQuery(_query))
+            {
+                ProcessAggregate(ref reader, ref writer);
+            }
+            else
+            {
+                while (ProcessRecord(ref reader, ref writer)) { }
+            }
 
             return writer.ToUtf8ByteArray();
         }
         
+        private void ProcessAggregate(ref JsonReader reader, ref JsonWriter writer)
+        {
+            var state = new AggregateProcessor(_query);
+
+            while (true)
+            {
+                var readResult = ReadRecord(ref reader);
+                if (readResult.IsNone)
+                {
+                    break;
+                }
+
+                var record = readResult.AsT0;
+                if (TestPredicate(record))
+                {
+                    state.ProcessRecord(record);
+                }
+            }
+
+            state.Write(ref writer);
+            writer.WriteRaw((byte) '\n');
+        }
+        
         private bool ProcessRecord(ref JsonReader reader, ref JsonWriter writer)
         {
-            reader.SkipWhiteSpace();
-            if (reader.GetCurrentOffsetUnsafe() >= reader.GetBufferUnsafe().Length)
+            var readResult = ReadRecord(ref reader);
+            if (readResult.IsNone)
             {
                 return false;
             }
 
-            var obj = Formatter.Deserialize(ref reader, StandardResolver.Default);
-
-            var wherePassed = _query.Where.Match(where => ExpressionEvaluator.EvaluateOnTable<bool>(where.Condition, _query.From, obj), _ => true);
-            if (wherePassed.IsSome && wherePassed.AsT0)
+            var record = readResult.AsT0;
+            if (TestPredicate(record))
             {
-                _recordWriter.Write(ref writer, obj);
+                _recordWriter.Write(ref writer, record);
                 writer.WriteRaw((byte) '\n');
             }
 
             return true;
+        }
+
+        private Option<object> ReadRecord(ref JsonReader reader)
+        {
+            reader.SkipWhiteSpace();
+            if (reader.GetCurrentOffsetUnsafe() >= reader.GetBufferUnsafe().Length)
+            {
+                return new None();
+            }
+
+            return Formatter.Deserialize(ref reader, StandardResolver.Default);
+        }
+
+        private bool TestPredicate(object record)
+        {
+            var wherePassed = _query.Where.Match(where => ExpressionEvaluator.EvaluateOnTable<bool>(where.Condition, _query.From, record), _ => true);
+
+            return wherePassed.IsSome && wherePassed.AsT0;
         }
     }
 }

--- a/SelectQuery.Evaluation/JsonRecordWriter.cs
+++ b/SelectQuery.Evaluation/JsonRecordWriter.cs
@@ -63,7 +63,7 @@ namespace SelectQuery.Evaluation
             }
         }
 
-        private static string GetColumnName(int index, Column column)
+        internal static string GetColumnName(int index, Column column)
         {
             if (column.Alias.IsSome)
             {

--- a/SelectQuery.Evaluation/QueryValidationError.cs
+++ b/SelectQuery.Evaluation/QueryValidationError.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace SelectQuery.Evaluation;
+
+[Serializable]
+public class QueryValidationError : Exception
+{
+    public QueryValidationError(string message) : base(message) { }
+}

--- a/SelectQuery.Evaluation/QueryValidator.cs
+++ b/SelectQuery.Evaluation/QueryValidator.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SelectParser.Queries;
+
+namespace SelectQuery.Evaluation;
+
+public class QueryValidator
+{
+    private readonly List<string> _errors = new();
+
+    public IReadOnlyCollection<string> Errors => _errors;
+    public bool HasErrors => _errors.Count > 0;
+
+    public void Validate(Query query)
+    {
+        if (!string.Equals(query.From.Table, "S3Object", StringComparison.OrdinalIgnoreCase))
+        {
+            AddError("complex table targets are not currently supported");
+        }
+
+        if (query.Order.IsSome)
+        {
+            AddError("ordering is not currently supported");
+        }
+
+        if (query.Select.IsT1 && query.Select.AsT1.Columns.Any(x => IsQualifiedStar(x.Expression)))
+        {
+            AddError("qualified star projections not currently supported");
+        }
+
+        if (IsAggregateQuery(query) && HasNonAggregateColumns(query))
+        {
+            throw new NotImplementedException("non-aggregate columns are not supported in an aggregate query");
+        }
+    }
+    
+    public void ThrowIfErrors()
+    {
+        switch (_errors.Count)
+        {
+            case 0: return;
+            case 1: throw new QueryValidationError(_errors[0]);
+            default: throw new AggregateException(_errors.Select(x => new QueryValidationError(x)));
+        }
+    }
+    
+    private static bool IsQualifiedStar(Expression expr)
+    {
+        while (true)
+        {
+            if (expr.IsT3) return expr.AsT3.Name == "*";
+            if (!expr.IsT4) return false;
+            expr = expr.AsT4.Expression;
+        }
+    }
+
+    internal static bool IsAggregateQuery(Query query) => query.Select.Match(_ => false, list => list.Columns.Any(IsAggregateColumn));
+    
+    private static bool HasNonAggregateColumns(Query query) => query.Select.Match(_ => true, list => list.Columns.Any(column => !IsAggregateColumn(column)));
+    private static bool IsAggregateColumn(Column column)
+    {
+        if (column.Expression.Value is Expression.FunctionExpression functionExpression)
+        {
+            return functionExpression.Function.Value is AggregateFunction;
+        }
+
+        return false;
+    }
+
+    private void AddError(string message)
+    {
+        _errors.Add(message);
+    }
+}


### PR DESCRIPTION
Closes #9 

Fairly simple to support without `GROUP BY`, uses a difference path to "normal" queries to allow it to build state across multiple input records