### PR TITLE
Optimise parsing suffix expressions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,9 +13,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: |
-          3.1.x
-          6.0.x
+        dotnet-version: 6.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: |          
-          3.1.x
-          6.0.x
+        dotnet-version: 6.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/SelectParser.Tests/SelectParser.Tests.csproj
+++ b/SelectParser.Tests/SelectParser.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/SelectQuery.Evaluation.Tests/SelectQuery.Evaluation.Tests.csproj
+++ b/SelectQuery.Evaluation.Tests/SelectQuery.Evaluation.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>

--- a/SelectQuery.Lambda/SelectQuery.Lambda.csproj
+++ b/SelectQuery.Lambda/SelectQuery.Lambda.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 

--- a/SelectQuery.Local/SelectQuery.Local.csproj
+++ b/SelectQuery.Local/SelectQuery.Local.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SelectQuery.Tests/SelectQuery.Tests.csproj
+++ b/SelectQuery.Tests/SelectQuery.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
Replace parsing the prefix then trying the suffix and backtracking just to re-parse the prefix
With parsing the prefix, then attempting to parse the suffix, and return the original prefix attempt if it fails

Takes parsing 42 "real world" queries from 900ms to 40ms