### PR TITLE
feat: Add optimised method for evaluating "IN" when all matches are strings

### DIFF
--- a/SelectParser/Queries/Expression.cs
+++ b/SelectParser/Queries/Expression.cs
@@ -422,11 +422,20 @@ public partial class Expression : OneOfBase<Expression.StringLiteral, Expression
         {
             Expression = expression;
             Matches = matches;
+
+            if (matches.All(x => x.IsT0))
+            {
+                StringMatches = new HashSet<string>(matches.Select(x => x.AsT0.Value));
+            }
         }
 
         public Expression Expression { get; }
         public IReadOnlyList<Expression> Matches { get; }
-
+        /// <summary>
+        /// if all matches are static strings, this set can be used for faster lookups
+        /// </summary>
+        public IReadOnlyCollection<string>? StringMatches { get; } 
+        
         protected bool Equals(In other)
         {
             return base.Equals(other) && Equals(Expression, other.Expression) && Matches.SequenceEqual(other.Matches);

--- a/SelectQuery.Benchmarks/EvaluationBenchmarks.cs
+++ b/SelectQuery.Benchmarks/EvaluationBenchmarks.cs
@@ -1,0 +1,69 @@
+﻿using System.Text;
+using BenchmarkDotNet.Attributes;
+using SelectParser;
+using SelectParser.Queries;
+using SelectQuery.Evaluation;
+
+namespace SelectQuery.Benchmarks;
+
+[ShortRunJob]
+[MemoryDiagnoser]
+public class EvaluationBenchmarks
+{
+    [ParamsSource(nameof(ValuesForTestCasesInput))]
+    public TestCaseInput Input { get; set; }
+    [ParamsSource(nameof(ValuesForTestCases))]
+    public TestCase Query { get; set; }
+
+    public static IEnumerable<TestCaseInput> ValuesForTestCasesInput
+    {
+        get
+        {
+            var smallRecords = Enumerable.Repeat("{\"a\":1,\"b\":2,\"c\":3,\"d\":{\"d1\":\"d1\",\"d2\":{\"d2.2\":true},\"d3\":[1,2,3]}}", 100);
+
+            var largeRecords = new List<string>();
+            for (var i = 0; i < 5_000; i++)
+            {
+                largeRecords.Add($"{{\"a\":1,\"b\":2,\"c\":3,{string.Join(",", Enumerable.Range(0, 300).Select(x => $"\"c{x}\": \"str{((x^i)*7)}\""))}}}");
+            }
+            
+            yield return new TestCaseInput("small", Encoding.UTF8.GetBytes(RecordsToString(smallRecords)));
+            yield return new TestCaseInput("large", Encoding.UTF8.GetBytes(RecordsToString(largeRecords)));
+        }
+    }
+    
+    public static IEnumerable<TestCase> ValuesForTestCases
+    {
+        get
+        {
+            yield return new TestCase("simple", "SELECT * FROM s3Object");
+            yield return new TestCase("projection", "SELECT s.a, s.b, s.c FROM s3Object s");
+            yield return new TestCase("filtered", "SELECT * FROM s3Object s WHERE s.a = 1 AND s.b = true AND s.c = 'def'");
+            yield return new TestCase("aggregated", "SELECT MAX(s.a), SUM(s.b), AVG(s.c) FROM s3Object s");
+            
+            yield return new TestCase("large projection", $"SELECT {string.Join(", ", Enumerable.Range(0, 300).Select(x => $"s.c{x}"))} FROM s3Object s");
+            yield return new TestCase("large IN filter", $"SELECT * FROM s3Object s WHERE s.c0 IN ({string.Join(", ", Enumerable.Range(0, 2000).Select(x => $"'str{x}'"))})");
+        }
+    }
+
+    
+    [Benchmark]
+    public byte[] Run() => new JsonLinesEvaluator(Query.Query).Run(Input.Input);
+
+    public static string RecordsToString(IEnumerable<string> expected) => string.Join("\n", expected) + "\n";
+
+    public class TestCase(string name, string queryString)
+    {
+        public string Name { get; } = name;
+        public Query Query { get; } = Parser.Parse(queryString).Value;
+
+        public override string ToString() => Name;
+    }   
+    public class TestCaseInput(string name, byte[] input)
+    {
+        public string Name { get; } = name;
+        public byte[] Input { get; } = input;
+
+        public override string ToString() => Name;
+    }
+}

--- a/SelectQuery.Benchmarks/Program.cs
+++ b/SelectQuery.Benchmarks/Program.cs
@@ -1,0 +1,4 @@
+﻿using BenchmarkDotNet.Running;
+using SelectQuery.Benchmarks;
+
+var summary = BenchmarkRunner.Run<EvaluationBenchmarks>();

--- a/SelectQuery.Benchmarks/SelectQuery.Benchmarks.csproj
+++ b/SelectQuery.Benchmarks/SelectQuery.Benchmarks.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\SelectParser\SelectParser.csproj" />
+      <ProjectReference Include="..\SelectQuery.Evaluation\SelectQuery.Evaluation.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/SelectQuery.Evaluation/ExpressionEvaluator.cs
+++ b/SelectQuery.Evaluation/ExpressionEvaluator.cs
@@ -187,19 +187,29 @@ public class ExpressionEvaluator
 
     private bool EvaluateIn(Expression.In inExpr, object obj)
     {
-        var value = Evaluate<object>(inExpr.Expression, obj);
-
-        foreach (var matchExpr in inExpr.Matches)
+        if (inExpr.StringMatches is not null)
         {
-            var matchValue = Evaluate<object>(matchExpr, obj);
+            var value = EvaluateToString(inExpr.Expression, obj);
+            if (value.IsNone) return false;
 
-            if (EvaluateEquality(value, matchValue))
-            {
-                return true;
-            }
+            return inExpr.StringMatches.Contains(value.AsT0);
         }
+        else
+        {
+            var value = Evaluate<object>(inExpr.Expression, obj);
 
-        return false;
+            foreach (var matchExpr in inExpr.Matches)
+            {
+                var matchValue = Evaluate<object>(matchExpr, obj);
+
+                if (EvaluateEquality(value, matchValue))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 
     private bool EvaluateLike(Expression.Like like, object obj)

--- a/SelectQuery.sln
+++ b/SelectQuery.sln
@@ -22,6 +22,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{688A425F-6
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SelectQuery.Benchmarks", "SelectQuery.Benchmarks\SelectQuery.Benchmarks.csproj", "{1ABEDF93-7850-4EA3-B397-7D6E971A0454}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,10 @@ Global
 		{B8650321-BEE1-4A88-BC9C-0D6F96A850E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B8650321-BEE1-4A88-BC9C-0D6F96A850E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B8650321-BEE1-4A88-BC9C-0D6F96A850E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1ABEDF93-7850-4EA3-B397-7D6E971A0454}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1ABEDF93-7850-4EA3-B397-7D6E971A0454}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1ABEDF93-7850-4EA3-B397-7D6E971A0454}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1ABEDF93-7850-4EA3-B397-7D6E971A0454}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
"large" dataset/"large IN filter" benchmark:
old - 709ms + 8,531MB memory allocated
new - 94ms + 231MB memory allocated


before:
![image](https://github.com/user-attachments/assets/ff3237e8-e69b-4075-a028-3b9aef38e290)


after:

| Method | Input | Query            | Mean          | Error         | StdDev       | Gen0        | Gen1       | Gen2      | Allocated     |
|------- |------ |----------------- |--------------:|--------------:|-------------:|------------:|-----------:|----------:|--------------:|
| **Run**    | **large** | **aggregated**       |  **90,362.94 μs** | **16,037.957 μs** |   **879.095 μs** |  **13500.0000** |  **2666.6667** |         **-** |  **248482.73 KB** |
| **Run**    | **large** | **filtered**         |  **88,598.45 μs** | **10,419.133 μs** |   **571.108 μs** |  **15333.3333** |  **2333.3333** |         **-** |  **281996.25 KB** |
| **Run**    | **large** | **large IN filter**  |  **94,312.09 μs** |  **1,729.001 μs** |    **94.772 μs** |  **12500.0000** |  **2333.3333** |         **-** |  **236278.06 KB** |
| **Run**    | **large** | **large projection** | **440,186.40 μs** | **54,968.911 μs** | **3,013.032 μs** | **183000.0000** | **21000.0000** |         **-** | **3459079.17 KB** |
| **Run**    | **large** | **projection**       |  **89,884.50 μs** | **13,150.913 μs** |   **720.846 μs** |  **13500.0000** |  **2500.0000** |         **-** |  **249459.45 KB** |
| **Run**    | **large** | **simple**           | **156,363.57 μs** | **11,670.918 μs** |   **639.722 μs** |  **12750.0000** |  **3000.0000** | **1000.0000** |  **306824.34 KB** |
| **Run**    | **small** | **aggregated**       |     **115.91 μs** |      **5.666 μs** |     **0.311 μs** |     **43.9453** |     **0.2441** |         **-** |     **807.66 KB** |
| **Run**    | **small** | **filtered**         |     **165.36 μs** |      **8.308 μs** |     **0.455 μs** |     **80.0781** |     **0.4883** |         **-** |    **1475.93 KB** |
| **Run**    | **small** | **large IN filter**  |      **80.36 μs** |      **3.645 μs** |     **0.200 μs** |     **25.5127** |     **0.1221** |         **-** |      **468.9 KB** |
| **Run**    | **small** | **large projection** |   **7,034.38 μs** |    **137.729 μs** |     **7.549 μs** |   **3703.1250** |    **23.4375** |         **-** |   **68122.51 KB** |
| **Run**    | **small** | **projection**       |     **136.17 μs** |     **11.358 μs** |     **0.623 μs** |     **44.6777** |     **0.4883** |         **-** |     **824.09 KB** |
| **Run**    | **small** | **simple**           |     **104.89 μs** |      **9.854 μs** |     **0.540 μs** |      **9.5215** |     **0.1221** |         **-** |     **175.08 KB** |
