### PR TITLE
feat(parser)!: Replace query parser with handwritten one

### DIFF
--- a/SelectParser.Tests/ParserExpressionTests.cs
+++ b/SelectParser.Tests/ParserExpressionTests.cs
@@ -1,6 +1,5 @@
 ﻿using SelectParser.Queries;
 using Xunit;
-using static SelectParser.Tests.ParserTestHelpers;
 
 namespace SelectParser.Tests;
 
@@ -13,24 +12,24 @@ public class ParserExpressionTests
     {
         var input = "a AND b OR c";
 
-        var result = Parse(Parser.BooleanOr, input);
+        var result = ParserTestHelpers.Parse(Parser.BooleanOr, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var binary = Assert.IsType<Expression.Binary>(expression.Value);
         Assert.Equal(BinaryOperator.Or, binary.Operator);
         var left = Assert.IsType<Expression.Binary>(binary.Left.Value);
         Assert.Equal(BinaryOperator.And, left.Operator);
-        AssertIdentifier("c", binary.Right);
+        ParserTestHelpers.AssertIdentifier("c", binary.Right);
     }
     [Fact]
     public void ParsingNopBooleanOr()
     {
         var input = "test";
 
-        var result = Parse(Parser.BooleanOr, input);
+        var result = ParserTestHelpers.Parse(Parser.BooleanOr, input);
 
-        var select = AssertSuccess(result);
-        AssertIdentifier("test", select);
+        var select = ParserTestHelpers.AssertSuccess(result);
+        ParserTestHelpers.AssertIdentifier("test", select);
     }
 
     #endregion
@@ -42,24 +41,24 @@ public class ParserExpressionTests
     {
         var input = "NOT a AND b";
 
-        var result = Parse(Parser.BooleanAnd, input);
+        var result = ParserTestHelpers.Parse(Parser.BooleanAnd, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var binary = Assert.IsType<Expression.Binary>(expression.Value);
         Assert.Equal(BinaryOperator.And, binary.Operator);
         var unary = Assert.IsType<Expression.Unary>(binary.Left.Value);
         Assert.Equal(UnaryOperator.Not, unary.Operator);
-        AssertIdentifier("b", binary.Right);
+        ParserTestHelpers.AssertIdentifier("b", binary.Right);
     }
     [Fact]
     public void ParsingNopBooleanAnd()
     {
         var input = "test";
 
-        var result = Parse(Parser.BooleanAnd, input);
+        var result = ParserTestHelpers.Parse(Parser.BooleanAnd, input);
 
-        var select = AssertSuccess(result);
-        AssertIdentifier("test", select);
+        var select = ParserTestHelpers.AssertSuccess(result);
+        ParserTestHelpers.AssertIdentifier("test", select);
     }
 
     #endregion
@@ -71,9 +70,9 @@ public class ParserExpressionTests
     {
         var input = "NOT a = b";
 
-        var result = Parse(Parser.BooleanUnary, input);
+        var result = ParserTestHelpers.Parse(Parser.BooleanUnary, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var unary = Assert.IsType<Expression.Unary>(expression.Value);
         Assert.Equal(UnaryOperator.Not, unary.Operator);
         var binary = Assert.IsType<Expression.Binary>(unary.Expression.Value);
@@ -84,10 +83,10 @@ public class ParserExpressionTests
     {
         var input = "test";
 
-        var result = Parse(Parser.BooleanUnary, input);
+        var result = ParserTestHelpers.Parse(Parser.BooleanUnary, input);
 
-        var select = AssertSuccess(result);
-        AssertIdentifier("test", select);
+        var select = ParserTestHelpers.AssertSuccess(result);
+        ParserTestHelpers.AssertIdentifier("test", select);
     }
 
     #endregion
@@ -99,23 +98,23 @@ public class ParserExpressionTests
     {
         var input = "a = b";
 
-        var result = Parse(Parser.Equality, input);
+        var result = ParserTestHelpers.Parse(Parser.Equality, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var binary = Assert.IsType<Expression.Binary>(expression.Value);
         Assert.Equal(BinaryOperator.Equal, binary.Operator);
-        AssertIdentifier("a", binary.Left);
-        AssertIdentifier("b", binary.Right);
+        ParserTestHelpers.AssertIdentifier("a", binary.Left);
+        ParserTestHelpers.AssertIdentifier("b", binary.Right);
     }
     [Fact]
     public void ParsingNopEquality()
     {
         var input = "test";
 
-        var result = Parse(Parser.Equality, input);
+        var result = ParserTestHelpers.Parse(Parser.Equality, input);
 
-        var select = AssertSuccess(result);
-        AssertIdentifier("test", select);
+        var select = ParserTestHelpers.AssertSuccess(result);
+        ParserTestHelpers.AssertIdentifier("test", select);
     }
 
     #endregion
@@ -127,23 +126,23 @@ public class ParserExpressionTests
     {
         var input = "a < b";
 
-        var result = Parse(Parser.Comparative, input);
+        var result = ParserTestHelpers.Parse(Parser.Comparative, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var binary = Assert.IsType<Expression.Binary>(expression.Value);
         Assert.Equal(BinaryOperator.Lesser, binary.Operator);
-        AssertIdentifier("a", binary.Left);
-        AssertIdentifier("b", binary.Right);
+        ParserTestHelpers.AssertIdentifier("a", binary.Left);
+        ParserTestHelpers.AssertIdentifier("b", binary.Right);
     }
     [Fact]
     public void ParsingNopComparative()
     {
         var input = "test";
 
-        var result = Parse(Parser.Comparative, input);
+        var result = ParserTestHelpers.Parse(Parser.Comparative, input);
 
-        var select = AssertSuccess(result);
-        AssertIdentifier("test", select);
+        var select = ParserTestHelpers.AssertSuccess(result);
+        ParserTestHelpers.AssertIdentifier("test", select);
     }
 
     #endregion
@@ -155,28 +154,28 @@ public class ParserExpressionTests
     {
         var input = "test LIKE '%'";
 
-        var result = Parse(Parser.Pattern, input);
+        var result = ParserTestHelpers.Parse(Parser.Pattern, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var like = Assert.IsType<Expression.Like>(expression.Value);
-        AssertIdentifier("test", like.Expression);
+        ParserTestHelpers.AssertIdentifier("test", like.Expression);
         var pattern = Assert.IsType<Expression.StringLiteral>(like.Pattern.Value);
         Assert.Equal("%", pattern.Value);
-        AssertNone(like.Escape);
+        ParserTestHelpers.AssertNone(like.Escape);
     }
     [Fact]
     public void ParsingPatternWithEscape()
     {
         var input = "test LIKE '%' ESCAPE 1";
 
-        var result = Parse(Parser.Pattern, input);
+        var result = ParserTestHelpers.Parse(Parser.Pattern, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var like = Assert.IsType<Expression.Like>(expression.Value);
-        AssertIdentifier("test", like.Expression);
+        ParserTestHelpers.AssertIdentifier("test", like.Expression);
         var pattern = Assert.IsType<Expression.StringLiteral>(like.Pattern.Value);
         Assert.Equal("%", pattern.Value);
-        var escape = AssertSome(like.Escape);
+        var escape = ParserTestHelpers.AssertSome(like.Escape);
         var escapeValue = Assert.IsType<Expression.NumberLiteral>(escape.Value);
         Assert.Equal(1, escapeValue.Value);
     }
@@ -185,10 +184,10 @@ public class ParserExpressionTests
     {
         var input = "test";
 
-        var result = Parse(Parser.Pattern, input);
+        var result = ParserTestHelpers.Parse(Parser.Pattern, input);
 
-        var select = AssertSuccess(result);
-        AssertIdentifier("test", select);
+        var select = ParserTestHelpers.AssertSuccess(result);
+        ParserTestHelpers.AssertIdentifier("test", select);
     }
 
     #endregion
@@ -200,12 +199,12 @@ public class ParserExpressionTests
     {
         var input = "test BETWEEN 1 AND 2 + 3";
 
-        var result = Parse(Parser.Containment, input);
+        var result = ParserTestHelpers.Parse(Parser.Containment, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var between = Assert.IsType<Expression.Between>(expression.Value);
         Assert.False(between.Negate);
-        AssertIdentifier("test", between.Expression);
+        ParserTestHelpers.AssertIdentifier("test", between.Expression);
         var lower = Assert.IsType<Expression.NumberLiteral>(between.Lower.Value);
         Assert.Equal(1, lower.Value);
         Assert.IsType<Expression.Binary>(between.Upper.Value);
@@ -215,12 +214,12 @@ public class ParserExpressionTests
     {
         var input = "test NOT BETWEEN 1 AND 2 + 3";
 
-        var result = Parse(Parser.Containment, input);
+        var result = ParserTestHelpers.Parse(Parser.Containment, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var between = Assert.IsType<Expression.Between>(expression.Value);
         Assert.True(between.Negate);
-        AssertIdentifier("test", between.Expression);
+        ParserTestHelpers.AssertIdentifier("test", between.Expression);
         var lower = Assert.IsType<Expression.NumberLiteral>(between.Lower.Value);
         Assert.Equal(1, lower.Value);
         Assert.IsType<Expression.Binary>(between.Upper.Value);
@@ -230,10 +229,10 @@ public class ParserExpressionTests
     {
         var input = "test";
 
-        var result = Parse(Parser.Containment, input);
+        var result = ParserTestHelpers.Parse(Parser.Containment, input);
 
-        var select = AssertSuccess(result);
-        AssertIdentifier("test", select);
+        var select = ParserTestHelpers.AssertSuccess(result);
+        ParserTestHelpers.AssertIdentifier("test", select);
     }
 
     #endregion
@@ -245,11 +244,11 @@ public class ParserExpressionTests
     {
         var input = "test IS NOT MISSING";
 
-        var result = Parse(Parser.Presence, input);
+        var result = ParserTestHelpers.Parse(Parser.Presence, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var presence = Assert.IsType<Expression.Presence>(expression.Value);
-        AssertIdentifier("test", presence.Expression);
+        ParserTestHelpers.AssertIdentifier("test", presence.Expression);
         Assert.False(presence.Negate);
     }
 
@@ -258,9 +257,9 @@ public class ParserExpressionTests
     {
         var input = "test IS MISSING";
 
-        var result = Parse(Parser.Presence, input);
+        var result = ParserTestHelpers.Parse(Parser.Presence, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var presence = Assert.IsType<Expression.Presence>(expression.Value);
         Assert.True(presence.Negate);
     }
@@ -270,10 +269,10 @@ public class ParserExpressionTests
     {
         var input = "test";
 
-        var result = Parse(Parser.Presence, input);
+        var result = ParserTestHelpers.Parse(Parser.Presence, input);
 
-        var select = AssertSuccess(result);
-        AssertIdentifier("test", select);
+        var select = ParserTestHelpers.AssertSuccess(result);
+        ParserTestHelpers.AssertIdentifier("test", select);
     }
 
     #endregion
@@ -285,11 +284,11 @@ public class ParserExpressionTests
     {
         var input = "test IS NULL";
 
-        var result = Parse(Parser.IsNull, input);
+        var result = ParserTestHelpers.Parse(Parser.IsNull, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var presence = Assert.IsType<Expression.IsNull>(expression.Value);
-        AssertIdentifier("test", presence.Expression);
+        ParserTestHelpers.AssertIdentifier("test", presence.Expression);
         Assert.False(presence.Negate);
     }
 
@@ -298,9 +297,9 @@ public class ParserExpressionTests
     {
         var input = "test IS NOT NULL";
 
-        var result = Parse(Parser.Presence, input);
+        var result = ParserTestHelpers.Parse(Parser.Presence, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var presence = Assert.IsType<Expression.IsNull>(expression.Value);
         Assert.True(presence.Negate);
     }
@@ -310,10 +309,10 @@ public class ParserExpressionTests
     {
         var input = "test";
 
-        var result = Parse(Parser.Presence, input);
+        var result = ParserTestHelpers.Parse(Parser.Presence, input);
 
-        var select = AssertSuccess(result);
-        AssertIdentifier("test", select);
+        var select = ParserTestHelpers.AssertSuccess(result);
+        ParserTestHelpers.AssertIdentifier("test", select);
     }
 
     #endregion
@@ -325,11 +324,11 @@ public class ParserExpressionTests
     {
         var input = "test in (1, 2 + 3)";
 
-        var result = Parse(Parser.Membership, input);
+        var result = ParserTestHelpers.Parse(Parser.Membership, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var @in = Assert.IsType<Expression.In>(expression.Value);
-        AssertIdentifier("test", @in.Expression);
+        ParserTestHelpers.AssertIdentifier("test", @in.Expression);
         Assert.Collection(@in.Matches,
             match =>
             {
@@ -348,9 +347,9 @@ public class ParserExpressionTests
     {
         var input = "123 + test IN (1, 2, 3)";
 
-        var result = Parse(Parser.Membership, input);
+        var result = ParserTestHelpers.Parse(Parser.Membership, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var @in = Assert.IsType<Expression.In>(expression.Value);
         Assert.IsType<Expression.Binary>(@in.Expression.Value);
     }
@@ -359,10 +358,10 @@ public class ParserExpressionTests
     {
         var input = "test";
 
-        var result = Parse(Parser.Membership, input);
+        var result = ParserTestHelpers.Parse(Parser.Membership, input);
 
-        var select = AssertSuccess(result);
-        AssertIdentifier("test", select);
+        var select = ParserTestHelpers.AssertSuccess(result);
+        ParserTestHelpers.AssertIdentifier("test", select);
     }
 
     #endregion
@@ -374,12 +373,12 @@ public class ParserExpressionTests
     {
         var input = "test + 123";
 
-        var result = Parse(Parser.Additive, input);
+        var result = ParserTestHelpers.Parse(Parser.Additive, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var binary = Assert.IsType<Expression.Binary>(expression.Value);
         Assert.Equal(BinaryOperator.Add, binary.Operator);
-        AssertIdentifier("test", binary.Left);
+        ParserTestHelpers.AssertIdentifier("test", binary.Left);
         var number = Assert.IsType<Expression.NumberLiteral>(binary.Right.Value);
         Assert.Equal(123, number.Value);
 
@@ -389,9 +388,9 @@ public class ParserExpressionTests
     {
         var input = "test * 123 + test";
 
-        var result = Parse(Parser.Additive, input);
+        var result = ParserTestHelpers.Parse(Parser.Additive, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var binary = Assert.IsType<Expression.Binary>(expression.Value);
         Assert.Equal(BinaryOperator.Add, binary.Operator);
         var left = Assert.IsType<Expression.Binary>(binary.Left.Value);
@@ -402,10 +401,10 @@ public class ParserExpressionTests
     {
         var input = "test";
 
-        var result = Parse(Parser.Additive, input);
+        var result = ParserTestHelpers.Parse(Parser.Additive, input);
 
-        var select = AssertSuccess(result);
-        AssertIdentifier("test", select);
+        var select = ParserTestHelpers.AssertSuccess(result);
+        ParserTestHelpers.AssertIdentifier("test", select);
     }
 
     #endregion
@@ -417,12 +416,12 @@ public class ParserExpressionTests
     {
         var input = "test * 123";
 
-        var result = Parse(Parser.Multiplicative, input);
+        var result = ParserTestHelpers.Parse(Parser.Multiplicative, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var binary = Assert.IsType<Expression.Binary>(expression.Value);
         Assert.Equal(BinaryOperator.Multiply, binary.Operator);
-        AssertIdentifier("test", binary.Left);
+        ParserTestHelpers.AssertIdentifier("test", binary.Left);
         var number = Assert.IsType<Expression.NumberLiteral>(binary.Right.Value);
         Assert.Equal(123, number.Value);
 
@@ -432,9 +431,9 @@ public class ParserExpressionTests
     {
         var input = "-test * 123";
 
-        var result = Parse(Parser.Multiplicative, input);
+        var result = ParserTestHelpers.Parse(Parser.Multiplicative, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var binary = Assert.IsType<Expression.Binary>(expression.Value);
         Assert.Equal(BinaryOperator.Multiply, binary.Operator);
         Assert.IsType<Expression.Unary>(binary.Left.Value);
@@ -444,10 +443,10 @@ public class ParserExpressionTests
     {
         var input = "test";
 
-        var result = Parse(Parser.Multiplicative, input);
+        var result = ParserTestHelpers.Parse(Parser.Multiplicative, input);
 
-        var select = AssertSuccess(result);
-        AssertIdentifier("test", select);
+        var select = ParserTestHelpers.AssertSuccess(result);
+        ParserTestHelpers.AssertIdentifier("test", select);
     }
 
     #endregion
@@ -459,22 +458,22 @@ public class ParserExpressionTests
     {
         var input = "-test";
 
-        var result = Parse(Parser.Unary, input);
+        var result = ParserTestHelpers.Parse(Parser.Unary, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var negate = Assert.IsType<Expression.Unary>(expression.Value);
         Assert.Equal(UnaryOperator.Negate, negate.Operator);
-        AssertIdentifier("test", negate.Expression);
+        ParserTestHelpers.AssertIdentifier("test", negate.Expression);
     }
     [Fact]
     public void ParsingNopNegate()
     {
         var input = "test";
 
-        var result = Parse(Parser.Unary, input);
+        var result = ParserTestHelpers.Parse(Parser.Unary, input);
 
-        var select = AssertSuccess(result);
-        AssertIdentifier("test", select);
+        var select = ParserTestHelpers.AssertSuccess(result);
+        ParserTestHelpers.AssertIdentifier("test", select);
     }
 
     #endregion
@@ -486,9 +485,9 @@ public class ParserExpressionTests
     {
         var input = "Test";
 
-        var result = Parse(Parser.Term, input);
+        var result = ParserTestHelpers.Parse(Parser.Term, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var identifier = Assert.IsType<Expression.Identifier>(expression.Value);
         Assert.Equal("Test", identifier.Name);
         Assert.False(identifier.CaseSensitive);
@@ -498,9 +497,9 @@ public class ParserExpressionTests
     {
         var input = "\"Test\"";
 
-        var result = Parse(Parser.Term, input);
+        var result = ParserTestHelpers.Parse(Parser.Term, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var identifier = Assert.IsType<Expression.Identifier>(expression.Value);
         Assert.Equal("Test", identifier.Name);
         Assert.True(identifier.CaseSensitive);
@@ -510,87 +509,105 @@ public class ParserExpressionTests
     {
         var input = "a.b";
 
-        var result = Parse(Parser.Term, input);
+        var result = ParserTestHelpers.Parse(Parser.Term, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var qualified = Assert.IsType<Expression.Qualified>(expression.Value);
         Assert.Equal("a", qualified.Qualification.Name);
-        AssertIdentifier("b", qualified.Expression);
+        ParserTestHelpers.AssertIdentifier("b", qualified.Expression);
+    }
+    [Fact]
+    public void ParsingDeepQualified()
+    {
+        var input = "a.b.c.d.e";
+
+        var result = ParserTestHelpers.Parse(Parser.Term, input);
+
+        var expression = ParserTestHelpers.AssertSuccess(result);
+        var qualified = Assert.IsType<Expression.Qualified>(expression.Value);
+        ParserTestHelpers.AssertIdentifier("a", qualified.Qualification);
+        qualified = qualified.Expression.AsT4;
+        ParserTestHelpers.AssertIdentifier("b", qualified.Qualification);
+        qualified = qualified.Expression.AsT4;
+        ParserTestHelpers.AssertIdentifier("c", qualified.Qualification);
+        qualified = qualified.Expression.AsT4;
+        ParserTestHelpers.AssertIdentifier("d", qualified.Qualification);
+        ParserTestHelpers.AssertIdentifier("e", qualified.Expression);
     }
     [Fact]
     public void ParsingQuotedQualified()
     {
         var input = "\"a\".b";
 
-        var result = Parse(Parser.Term, input);
+        var result = ParserTestHelpers.Parse(Parser.Term, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var qualified = Assert.IsType<Expression.Qualified>(expression.Value);
         Assert.Equal("a", qualified.Qualification.Name);
         Assert.True(qualified.Qualification.CaseSensitive);
-        AssertIdentifier("b", qualified.Expression);
+        ParserTestHelpers.AssertIdentifier("b", qualified.Expression);
     }
     [Fact]
     public void ParsingQualifiedStar()
     {
         var input = "a.*";
 
-        var result = Parse(Parser.Term, input);
+        var result = ParserTestHelpers.Parse(Parser.Term, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var qualified = Assert.IsType<Expression.Qualified>(expression.Value);
         Assert.Equal("a", qualified.Qualification.Name);
-        AssertIdentifier("*", qualified.Expression);
+        ParserTestHelpers.AssertIdentifier("*", qualified.Expression);
     }
     [Fact]
     public void ParsingAggregateFunction()
     {
         var input = "AVG(Value)";
 
-        var result = Parse(Parser.Term, input);
+        var result = ParserTestHelpers.Parse(Parser.Term, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var function = Assert.IsType<Expression.FunctionExpression>(expression.Value);
         var aggregate = Assert.IsType<AggregateFunction>(function.Function.Value);
         var average = Assert.IsType<AggregateFunction.Average>(aggregate.Value);
-        AssertIdentifier("Value", average.Expression);
+        ParserTestHelpers.AssertIdentifier("Value", average.Expression);
     }
     [Fact]
     public void ParsingScalarFunction()
     {
         var input = "LOWER(Value)";
 
-        var result = Parse(Parser.Term, input);
+        var result = ParserTestHelpers.Parse(Parser.Term, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var function = Assert.IsType<Expression.FunctionExpression>(expression.Value);
         var scalar = Assert.IsType<ScalarFunction>(function.Function.Value);
-        AssertIdentifier("LOWER", scalar.Identifier);
+        ParserTestHelpers.AssertIdentifier("LOWER", scalar.Identifier);
         Assert.Equal(1, scalar.Arguments.Count);
-        AssertIdentifier("Value", scalar.Arguments[0]);
+        ParserTestHelpers.AssertIdentifier("Value", scalar.Arguments[0]);
     }
     [Fact]
     public void ParsingCountColumn()
     {
         var input = "COUNT(Value)";
 
-        var result = Parse(Parser.Term, input);
+        var result = ParserTestHelpers.Parse(Parser.Term, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var function = Assert.IsType<Expression.FunctionExpression>(expression.Value);
         var aggregate = Assert.IsType<AggregateFunction>(function.Function.Value);
         var count = Assert.IsType<AggregateFunction.Count>(aggregate.Value);
         Assert.True(count.Expression.IsSome);
-        AssertIdentifier("Value", count.Expression.AsT0);
+        ParserTestHelpers.AssertIdentifier("Value", count.Expression.AsT0);
     }
     [Fact]
     public void ParsingCountStar()
     {
         var input = "COUNT(*)";
 
-        var result = Parse(Parser.Term, input);
+        var result = ParserTestHelpers.Parse(Parser.Term, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var function = Assert.IsType<Expression.FunctionExpression>(expression.Value);
         var aggregate = Assert.IsType<AggregateFunction>(function.Function.Value);
         var count = Assert.IsType<AggregateFunction.Count>(aggregate.Value);
@@ -601,9 +618,9 @@ public class ParserExpressionTests
     {
         var input = "123";
 
-        var result = Parse(Parser.Term, input);
+        var result = ParserTestHelpers.Parse(Parser.Term, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var identifier = Assert.IsType<Expression.NumberLiteral>(expression.Value);
         Assert.Equal(123, identifier.Value);
     }
@@ -612,9 +629,9 @@ public class ParserExpressionTests
     {
         var input = "'test'";
 
-        var result = Parse(Parser.Term, input);
+        var result = ParserTestHelpers.Parse(Parser.Term, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var identifier = Assert.IsType<Expression.StringLiteral>(expression.Value);
         Assert.Equal("test", identifier.Value);
     }
@@ -623,9 +640,9 @@ public class ParserExpressionTests
     {
         var input = "true";
 
-        var result = Parse(Parser.Term, input);
+        var result = ParserTestHelpers.Parse(Parser.Term, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var identifier = Assert.IsType<Expression.BooleanLiteral>(expression.Value);
         Assert.True(identifier.Value);
     }
@@ -635,30 +652,12 @@ public class ParserExpressionTests
     {
         var input = "(a or b)";
 
-        var result = Parse(Parser.Term, input);
+        var result = ParserTestHelpers.Parse(Parser.Term, input);
 
-        var expression = AssertSuccess(result);
+        var expression = ParserTestHelpers.AssertSuccess(result);
         var binary = Assert.IsType<Expression.Binary>(expression.Value);
         Assert.Equal(BinaryOperator.Or, binary.Operator);
     }
         
-    #endregion
-
-    #region String Concat
-
-    [Fact]
-    public void ParsingStringConcatenation()
-    {
-        var input = "a = b||'x'";
-
-        var result = Parse(Parser.Expression, input);
-
-        var expression = AssertSuccess(result);
-        var binary = Assert.IsType<Expression.Binary>(expression.Value);
-        Assert.Equal(BinaryOperator.Equal, binary.Operator);
-        var concat = Assert.IsType<Expression.Binary>((Expression.Binary) binary.Right);
-        Assert.Equal(BinaryOperator.Concat, concat.Operator);
-    }
-
     #endregion
 }

--- a/SelectParser.Tests/ParserExpressionTests.cs
+++ b/SelectParser.Tests/ParserExpressionTests.cs
@@ -15,9 +15,9 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.BooleanOr, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var binary = Assert.IsType<Expression.Binary>(expression.Value);
+        var binary = Assert.IsType<Expression.Binary>(expression);
         Assert.Equal(BinaryOperator.Or, binary.Operator);
-        var left = Assert.IsType<Expression.Binary>(binary.Left.Value);
+        var left = Assert.IsType<Expression.Binary>(binary.Left);
         Assert.Equal(BinaryOperator.And, left.Operator);
         ParserTestHelpers.AssertIdentifier("c", binary.Right);
     }
@@ -44,9 +44,9 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.BooleanAnd, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var binary = Assert.IsType<Expression.Binary>(expression.Value);
+        var binary = Assert.IsType<Expression.Binary>(expression);
         Assert.Equal(BinaryOperator.And, binary.Operator);
-        var unary = Assert.IsType<Expression.Unary>(binary.Left.Value);
+        var unary = Assert.IsType<Expression.Unary>(binary.Left);
         Assert.Equal(UnaryOperator.Not, unary.Operator);
         ParserTestHelpers.AssertIdentifier("b", binary.Right);
     }
@@ -73,9 +73,9 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.BooleanUnary, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var unary = Assert.IsType<Expression.Unary>(expression.Value);
+        var unary = Assert.IsType<Expression.Unary>(expression);
         Assert.Equal(UnaryOperator.Not, unary.Operator);
-        var binary = Assert.IsType<Expression.Binary>(unary.Expression.Value);
+        var binary = Assert.IsType<Expression.Binary>(unary.Expression);
         Assert.Equal(BinaryOperator.Equal, binary.Operator);
     }
     [Fact]
@@ -101,7 +101,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Equality, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var binary = Assert.IsType<Expression.Binary>(expression.Value);
+        var binary = Assert.IsType<Expression.Binary>(expression);
         Assert.Equal(BinaryOperator.Equal, binary.Operator);
         ParserTestHelpers.AssertIdentifier("a", binary.Left);
         ParserTestHelpers.AssertIdentifier("b", binary.Right);
@@ -129,7 +129,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Comparative, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var binary = Assert.IsType<Expression.Binary>(expression.Value);
+        var binary = Assert.IsType<Expression.Binary>(expression);
         Assert.Equal(BinaryOperator.Lesser, binary.Operator);
         ParserTestHelpers.AssertIdentifier("a", binary.Left);
         ParserTestHelpers.AssertIdentifier("b", binary.Right);
@@ -157,9 +157,9 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Pattern, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var like = Assert.IsType<Expression.Like>(expression.Value);
+        var like = Assert.IsType<Expression.Like>(expression);
         ParserTestHelpers.AssertIdentifier("test", like.Expression);
-        var pattern = Assert.IsType<Expression.StringLiteral>(like.Pattern.Value);
+        var pattern = Assert.IsType<Expression.StringLiteral>(like.Pattern);
         Assert.Equal("%", pattern.Value);
         ParserTestHelpers.AssertNone(like.Escape);
     }
@@ -171,12 +171,12 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Pattern, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var like = Assert.IsType<Expression.Like>(expression.Value);
+        var like = Assert.IsType<Expression.Like>(expression);
         ParserTestHelpers.AssertIdentifier("test", like.Expression);
-        var pattern = Assert.IsType<Expression.StringLiteral>(like.Pattern.Value);
+        var pattern = Assert.IsType<Expression.StringLiteral>(like.Pattern);
         Assert.Equal("%", pattern.Value);
         var escape = ParserTestHelpers.AssertSome(like.Escape);
-        var escapeValue = Assert.IsType<Expression.NumberLiteral>(escape.Value);
+        var escapeValue = Assert.IsType<Expression.NumberLiteral>(escape);
         Assert.Equal(1, escapeValue.Value);
     }
     [Fact]
@@ -202,12 +202,12 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Containment, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var between = Assert.IsType<Expression.Between>(expression.Value);
+        var between = Assert.IsType<Expression.Between>(expression);
         Assert.False(between.Negate);
         ParserTestHelpers.AssertIdentifier("test", between.Expression);
-        var lower = Assert.IsType<Expression.NumberLiteral>(between.Lower.Value);
+        var lower = Assert.IsType<Expression.NumberLiteral>(between.Lower);
         Assert.Equal(1, lower.Value);
-        Assert.IsType<Expression.Binary>(between.Upper.Value);
+        Assert.IsType<Expression.Binary>(between.Upper);
     }
     [Fact]
     public void ParsingNotContainment()
@@ -217,12 +217,12 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Containment, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var between = Assert.IsType<Expression.Between>(expression.Value);
+        var between = Assert.IsType<Expression.Between>(expression);
         Assert.True(between.Negate);
         ParserTestHelpers.AssertIdentifier("test", between.Expression);
-        var lower = Assert.IsType<Expression.NumberLiteral>(between.Lower.Value);
+        var lower = Assert.IsType<Expression.NumberLiteral>(between.Lower);
         Assert.Equal(1, lower.Value);
-        Assert.IsType<Expression.Binary>(between.Upper.Value);
+        Assert.IsType<Expression.Binary>(between.Upper);
     }
     [Fact]
     public void ParsingNopContainment()
@@ -247,7 +247,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Presence, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var presence = Assert.IsType<Expression.Presence>(expression.Value);
+        var presence = Assert.IsType<Expression.Presence>(expression);
         ParserTestHelpers.AssertIdentifier("test", presence.Expression);
         Assert.False(presence.Negate);
     }
@@ -260,7 +260,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Presence, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var presence = Assert.IsType<Expression.Presence>(expression.Value);
+        var presence = Assert.IsType<Expression.Presence>(expression);
         Assert.True(presence.Negate);
     }
 
@@ -287,7 +287,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.IsNull, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var presence = Assert.IsType<Expression.IsNull>(expression.Value);
+        var presence = Assert.IsType<Expression.IsNull>(expression);
         ParserTestHelpers.AssertIdentifier("test", presence.Expression);
         Assert.False(presence.Negate);
     }
@@ -300,7 +300,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Presence, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var presence = Assert.IsType<Expression.IsNull>(expression.Value);
+        var presence = Assert.IsType<Expression.IsNull>(expression);
         Assert.True(presence.Negate);
     }
 
@@ -327,17 +327,17 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Membership, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var @in = Assert.IsType<Expression.In>(expression.Value);
+        var @in = Assert.IsType<Expression.In>(expression);
         ParserTestHelpers.AssertIdentifier("test", @in.Expression);
         Assert.Collection(@in.Matches,
             match =>
             {
-                var num = Assert.IsType<Expression.NumberLiteral>(match.Value);
+                var num = Assert.IsType<Expression.NumberLiteral>(match);
                 Assert.Equal(1, num.Value);
             },
             match =>
             {
-                var binary = Assert.IsType<Expression.Binary>(match.Value);
+                var binary = Assert.IsType<Expression.Binary>(match);
                 Assert.Equal(BinaryOperator.Add, binary.Operator);
             }
         );
@@ -350,8 +350,8 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Membership, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var @in = Assert.IsType<Expression.In>(expression.Value);
-        Assert.IsType<Expression.Binary>(@in.Expression.Value);
+        var @in = Assert.IsType<Expression.In>(expression);
+        Assert.IsType<Expression.Binary>(@in.Expression);
     }
     [Fact]
     public void ParsingNopMembership()
@@ -376,10 +376,10 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Additive, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var binary = Assert.IsType<Expression.Binary>(expression.Value);
+        var binary = Assert.IsType<Expression.Binary>(expression);
         Assert.Equal(BinaryOperator.Add, binary.Operator);
         ParserTestHelpers.AssertIdentifier("test", binary.Left);
-        var number = Assert.IsType<Expression.NumberLiteral>(binary.Right.Value);
+        var number = Assert.IsType<Expression.NumberLiteral>(binary.Right);
         Assert.Equal(123, number.Value);
 
     }
@@ -391,9 +391,9 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Additive, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var binary = Assert.IsType<Expression.Binary>(expression.Value);
+        var binary = Assert.IsType<Expression.Binary>(expression);
         Assert.Equal(BinaryOperator.Add, binary.Operator);
-        var left = Assert.IsType<Expression.Binary>(binary.Left.Value);
+        var left = Assert.IsType<Expression.Binary>(binary.Left);
         Assert.Equal(BinaryOperator.Multiply, left.Operator);
     }
     [Fact]
@@ -419,10 +419,10 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Multiplicative, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var binary = Assert.IsType<Expression.Binary>(expression.Value);
+        var binary = Assert.IsType<Expression.Binary>(expression);
         Assert.Equal(BinaryOperator.Multiply, binary.Operator);
         ParserTestHelpers.AssertIdentifier("test", binary.Left);
-        var number = Assert.IsType<Expression.NumberLiteral>(binary.Right.Value);
+        var number = Assert.IsType<Expression.NumberLiteral>(binary.Right);
         Assert.Equal(123, number.Value);
 
     }
@@ -434,9 +434,9 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Multiplicative, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var binary = Assert.IsType<Expression.Binary>(expression.Value);
+        var binary = Assert.IsType<Expression.Binary>(expression);
         Assert.Equal(BinaryOperator.Multiply, binary.Operator);
-        Assert.IsType<Expression.Unary>(binary.Left.Value);
+        Assert.IsType<Expression.Unary>(binary.Left);
     }
     [Fact]
     public void ParsingNopMultiplicative()
@@ -461,7 +461,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Unary, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var negate = Assert.IsType<Expression.Unary>(expression.Value);
+        var negate = Assert.IsType<Expression.Unary>(expression);
         Assert.Equal(UnaryOperator.Negate, negate.Operator);
         ParserTestHelpers.AssertIdentifier("test", negate.Expression);
     }
@@ -488,7 +488,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Term, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var identifier = Assert.IsType<Expression.Identifier>(expression.Value);
+        var identifier = Assert.IsType<Expression.Identifier>(expression);
         Assert.Equal("Test", identifier.Name);
         Assert.False(identifier.CaseSensitive);
     }
@@ -500,7 +500,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Term, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var identifier = Assert.IsType<Expression.Identifier>(expression.Value);
+        var identifier = Assert.IsType<Expression.Identifier>(expression);
         Assert.Equal("Test", identifier.Name);
         Assert.True(identifier.CaseSensitive);
     }
@@ -512,7 +512,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Term, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var qualified = Assert.IsType<Expression.Qualified>(expression.Value);
+        var qualified = Assert.IsType<Expression.Qualified>(expression);
         Assert.Equal("a", qualified.Qualification.Name);
         ParserTestHelpers.AssertIdentifier("b", qualified.Expression);
     }
@@ -524,13 +524,13 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Term, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var qualified = Assert.IsType<Expression.Qualified>(expression.Value);
+        var qualified = Assert.IsType<Expression.Qualified>(expression);
         ParserTestHelpers.AssertIdentifier("a", qualified.Qualification);
-        qualified = qualified.Expression.AsT4;
+        qualified = (Expression.Qualified) qualified.Expression;
         ParserTestHelpers.AssertIdentifier("b", qualified.Qualification);
-        qualified = qualified.Expression.AsT4;
+        qualified = (Expression.Qualified) qualified.Expression;
         ParserTestHelpers.AssertIdentifier("c", qualified.Qualification);
-        qualified = qualified.Expression.AsT4;
+        qualified = (Expression.Qualified) qualified.Expression;
         ParserTestHelpers.AssertIdentifier("d", qualified.Qualification);
         ParserTestHelpers.AssertIdentifier("e", qualified.Expression);
     }
@@ -542,7 +542,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Term, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var qualified = Assert.IsType<Expression.Qualified>(expression.Value);
+        var qualified = Assert.IsType<Expression.Qualified>(expression);
         Assert.Equal("a", qualified.Qualification.Name);
         Assert.True(qualified.Qualification.CaseSensitive);
         ParserTestHelpers.AssertIdentifier("b", qualified.Expression);
@@ -555,7 +555,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Term, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var qualified = Assert.IsType<Expression.Qualified>(expression.Value);
+        var qualified = Assert.IsType<Expression.Qualified>(expression);
         Assert.Equal("a", qualified.Qualification.Name);
         ParserTestHelpers.AssertIdentifier("*", qualified.Expression);
     }
@@ -567,9 +567,9 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Term, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var function = Assert.IsType<Expression.FunctionExpression>(expression.Value);
-        var aggregate = Assert.IsType<AggregateFunction>(function.Function.Value);
-        var average = Assert.IsType<AggregateFunction.Average>(aggregate.Value);
+        var function = Assert.IsType<Expression.FunctionExpression>(expression);
+        var aggregate = Assert.IsAssignableFrom<AggregateFunction>(function.Function);
+        var average = Assert.IsType<AggregateFunction.Average>(aggregate);
         ParserTestHelpers.AssertIdentifier("Value", average.Expression);
     }
     [Fact]
@@ -580,10 +580,10 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Term, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var function = Assert.IsType<Expression.FunctionExpression>(expression.Value);
-        var scalar = Assert.IsType<ScalarFunction>(function.Function.Value);
+        var function = Assert.IsType<Expression.FunctionExpression>(expression);
+        var scalar = Assert.IsType<ScalarFunction>(function.Function);
         ParserTestHelpers.AssertIdentifier("LOWER", scalar.Identifier);
-        Assert.Equal(1, scalar.Arguments.Count);
+        Assert.Single(scalar.Arguments);
         ParserTestHelpers.AssertIdentifier("Value", scalar.Arguments[0]);
     }
     [Fact]
@@ -594,9 +594,9 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Term, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var function = Assert.IsType<Expression.FunctionExpression>(expression.Value);
-        var aggregate = Assert.IsType<AggregateFunction>(function.Function.Value);
-        var count = Assert.IsType<AggregateFunction.Count>(aggregate.Value);
+        var function = Assert.IsType<Expression.FunctionExpression>(expression);
+        var aggregate = Assert.IsAssignableFrom<AggregateFunction>(function.Function);
+        var count = Assert.IsType<AggregateFunction.Count>(aggregate);
         Assert.True(count.Expression.IsSome);
         ParserTestHelpers.AssertIdentifier("Value", count.Expression.AsT0);
     }
@@ -608,9 +608,9 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Term, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var function = Assert.IsType<Expression.FunctionExpression>(expression.Value);
-        var aggregate = Assert.IsType<AggregateFunction>(function.Function.Value);
-        var count = Assert.IsType<AggregateFunction.Count>(aggregate.Value);
+        var function = Assert.IsType<Expression.FunctionExpression>(expression);
+        var aggregate = Assert.IsAssignableFrom<AggregateFunction>(function.Function);
+        var count = Assert.IsType<AggregateFunction.Count>(aggregate);
         Assert.True(count.Expression.IsNone);
     }
     [Fact]
@@ -621,7 +621,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Term, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var identifier = Assert.IsType<Expression.NumberLiteral>(expression.Value);
+        var identifier = Assert.IsType<Expression.NumberLiteral>(expression);
         Assert.Equal(123, identifier.Value);
     }
     [Fact]
@@ -632,7 +632,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Term, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var identifier = Assert.IsType<Expression.StringLiteral>(expression.Value);
+        var identifier = Assert.IsType<Expression.StringLiteral>(expression);
         Assert.Equal("test", identifier.Value);
     }
     [Fact]
@@ -643,7 +643,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Term, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var identifier = Assert.IsType<Expression.BooleanLiteral>(expression.Value);
+        var identifier = Assert.IsType<Expression.BooleanLiteral>(expression);
         Assert.True(identifier.Value);
     }
 
@@ -655,7 +655,7 @@ public class ParserExpressionTests
         var result = ParserTestHelpers.Parse(Parser.Term, input);
 
         var expression = ParserTestHelpers.AssertSuccess(result);
-        var binary = Assert.IsType<Expression.Binary>(expression.Value);
+        var binary = Assert.IsType<Expression.Binary>(expression);
         Assert.Equal(BinaryOperator.Or, binary.Operator);
     }
         

--- a/SelectParser.Tests/ParserQueryTests.cs
+++ b/SelectParser.Tests/ParserQueryTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using SelectParser.Queries;
 using Xunit;
 using static SelectParser.Tests.ParserTestHelpers;
 
@@ -15,7 +16,7 @@ public class ParserQueryTests
         var result = Parse(Parser.Query, input);
 
         var query = AssertSuccess(result);
-        Assert.True(query.Select.IsT0);
+        Assert.IsType<SelectClause.Star>(query.Select);
         Assert.Equal("test", query.From.Table);
     }
 
@@ -37,7 +38,7 @@ public class ParserQueryTests
         var result = Parse(Parser.Query, input);
 
         var query = AssertSuccess(result);
-        Assert.True(query.Select.IsT0);
+        Assert.IsType<SelectClause.Star>(query.Select);
         Assert.Equal("test", query.From.Table);
         var where = AssertSome(query.Where);
         AssertIdentifier("col", where.Condition);
@@ -51,7 +52,7 @@ public class ParserQueryTests
         var result = Parse(Parser.Query, input);
 
         var query = AssertSuccess(result);
-        Assert.True(query.Select.IsT0);
+        Assert.IsType<SelectClause.Star>(query.Select);
         Assert.Equal("test", query.From.Table);
         var order = AssertSome(query.Order);
         var (orderExpression, _) = Assert.Single(order.Columns);
@@ -66,7 +67,7 @@ public class ParserQueryTests
         var result = Parse(Parser.Query, input);
 
         var query = AssertSuccess(result);
-        Assert.True(query.Select.IsT0);
+        Assert.IsType<SelectClause.Star>(query.Select);
         Assert.Equal("test", query.From.Table);
         var limit = AssertSome(query.Limit);
         Assert.Equal(10, limit.Limit);
@@ -80,7 +81,7 @@ public class ParserQueryTests
         var result = Parse(Parser.Query, input);
 
         var query = AssertSuccess(result);
-        Assert.True(query.Select.IsT0);
+        Assert.IsType<SelectClause.Star>(query.Select);
         Assert.Equal("test", query.From.Table);
         var where = AssertSome(query.Where);
         AssertIdentifier("col1", where.Condition);

--- a/SelectParser.Tests/ParserQueryTests.cs
+++ b/SelectParser.Tests/ParserQueryTests.cs
@@ -96,7 +96,7 @@ public class ParserQueryTests
     {
         var input = "SELECT * FROM test ORDER BY col1 WHERE col2";
 
-        var result = Parse(Parser.Query, input);
+        var result = Parser.Parse(input);
 
         AssertFailed(result);
     }

--- a/SelectParser.Tests/ParserSelectTests.cs
+++ b/SelectParser.Tests/ParserSelectTests.cs
@@ -15,7 +15,7 @@ public class ParserSelectTests
         var result = Parse(Parser.SelectClause, input);
 
         var select = AssertSuccess(result);
-        Assert.True(select.IsT0);
+        Assert.IsType<SelectClause.Star>(select);
     }
     [Fact]
     public void ParsingSelectColumn()
@@ -81,9 +81,5 @@ public class ParserSelectTests
         AssertFailed(result);
     }
 
-    private IReadOnlyCollection<Column> AssertColumns(SelectClause clause)
-    {
-        Assert.True(clause.IsT1);
-        return clause.AsT1.Columns;
-    }
+    private IReadOnlyCollection<Column> AssertColumns(SelectClause clause) => Assert.IsType<SelectClause.List>(clause).Columns;
 }

--- a/SelectParser.Tests/ParserTestHelpers.cs
+++ b/SelectParser.Tests/ParserTestHelpers.cs
@@ -49,7 +49,7 @@ public static class ParserTestHelpers
 
     public static void AssertIdentifier(string expected, Expression expression)
     {
-        var identifier = Assert.IsType<Expression.Identifier>(expression.Value);
+        var identifier = Assert.IsType<Expression.Identifier>(expression);
         Assert.Equal(expected, identifier.Name);
     }
 }

--- a/SelectParser.Tests/SelectTokenizerTests.cs
+++ b/SelectParser.Tests/SelectTokenizerTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using Xunit;
+﻿using Xunit;
 
 namespace SelectParser.Tests;
 
@@ -21,12 +20,11 @@ public class SelectTokenizerTests
     [InlineData("select", SelectToken.Select)]
     public void TestKeywordsAreParsedCorrectly(string input, SelectToken expected)
     {
-        var tokenizer = new SelectTokenizer();
+        var tokenizer = new SelectTokenizer(input);
 
-        var output = tokenizer.Tokenize(input).ToList();
+        var token = SelectTokenizer.Read(ref tokenizer);
 
-        var token = Assert.Single(output);
-        Assert.Equal(expected, token.Kind);
+        Assert.Equal(expected, token.Type);
     }
 
     [Theory]
@@ -38,12 +36,11 @@ public class SelectTokenizerTests
     [InlineData("\"SELECT\"", "\"SELECT\"")]
     public void TestIdentifiersAreParserCorrectly(string input, string expected)
     {
-        var tokenizer = new SelectTokenizer();
+        var tokenizer = new SelectTokenizer(input);
 
-        var output = tokenizer.Tokenize(input).ToList();
+        var token = SelectTokenizer.Read(ref tokenizer);
 
-        var token = Assert.Single(output);
-        Assert.Equal(SelectToken.Identifier, token.Kind);
+        Assert.Equal(SelectToken.Identifier, token.Type);
         Assert.Equal(expected, token.ToStringValue());
     }
 
@@ -52,12 +49,11 @@ public class SelectTokenizerTests
     [InlineData("'Te''st'", "'Te''st'")]
     public void TestStringLiteralsAreParserCorrectly(string input, string expected)
     {
-        var tokenizer = new SelectTokenizer();
+        var tokenizer = new SelectTokenizer(input);
 
-        var output = tokenizer.Tokenize(input).ToList();
+        var token = SelectTokenizer.Read(ref tokenizer);
 
-        var token = Assert.Single(output);
-        Assert.Equal(SelectToken.StringLiteral, token.Kind);
+        Assert.Equal(SelectToken.StringLiteral, token.Type);
         Assert.Equal(expected, token.ToStringValue());
     }
 
@@ -71,12 +67,11 @@ public class SelectTokenizerTests
     [InlineData("0.10", "0.10")]
     public void TestNumberLiteralsAreParserCorrectly(string input, string expected)
     {
-        var tokenizer = new SelectTokenizer();
+        var tokenizer = new SelectTokenizer(input);
 
-        var output = tokenizer.Tokenize(input).ToList();
+        var token = SelectTokenizer.Read(ref tokenizer);
 
-        var token = Assert.Single(output);
-        Assert.Equal(SelectToken.NumberLiteral, token.Kind);
+        Assert.Equal(SelectToken.NumberLiteral, token.Type);
         Assert.Equal(expected, token.ToStringValue());
     }
 
@@ -87,12 +82,11 @@ public class SelectTokenizerTests
     [InlineData("false", "false")]
     public void TestBooleanLiteralsAreParserCorrectly(string input, string expected)
     {
-        var tokenizer = new SelectTokenizer();
+        var tokenizer = new SelectTokenizer(input);
 
-        var output = tokenizer.Tokenize(input).ToList();
+        var token = SelectTokenizer.Read(ref tokenizer);
 
-        var token = Assert.Single(output);
-        Assert.Equal(SelectToken.BooleanLiteral, token.Kind);
+        Assert.Equal(SelectToken.BooleanLiteral, token.Type);
         Assert.Equal(expected, token.ToStringValue());
     }
 
@@ -132,28 +126,30 @@ public class SelectTokenizerTests
     [InlineData("ESCAPE", SelectToken.Escape)]
     public void TestOperatorsAreParsedCorrectly(string input, SelectToken expected)
     {
-        var tokenizer = new SelectTokenizer();
+        var tokenizer = new SelectTokenizer(input);
 
-        var output = tokenizer.Tokenize(input).ToList();
+        var token = SelectTokenizer.Read(ref tokenizer);
 
-        var token = Assert.Single(output);
-        Assert.Equal(expected, token.Kind);
+        Assert.Equal(expected, token.Type);
     }
 
     [Fact]
     public void TestComplexQueryIsParsedCorrectly()
     {
         var input = "SELECT * FROM Test WHERE m = 5";
-        var expected = new[]
+        var expectedTokens = new[]
         {
             SelectToken.Select, SelectToken.Star,
             SelectToken.From, SelectToken.Identifier,
-            SelectToken.Where,SelectToken.Identifier,SelectToken.Equal,SelectToken.NumberLiteral
+            SelectToken.Where,SelectToken.Identifier,SelectToken.Equal,SelectToken.NumberLiteral,
+            SelectToken.Eof
         };
-        var tokenizer = new SelectTokenizer();
+        var tokenizer = new SelectTokenizer(input);
 
-        var output = tokenizer.Tokenize(input).ToList();
-
-        Assert.Equal(expected, output.Select(x => x.Kind));
+        foreach (var expectedToken in expectedTokens)
+        {
+            var token = SelectTokenizer.Read(ref tokenizer);
+            Assert.Equal(expectedToken, token.Type);
+        }
     }
 }

--- a/SelectParser/Option.cs
+++ b/SelectParser/Option.cs
@@ -1,27 +1,47 @@
 ﻿using System;
-using OneOf;
+using System.Collections.Generic;
 using OneOf.Types;
 
 namespace SelectParser;
 
-public class Option<T> : OneOfBase<T, None>
+public readonly struct Option<T> : IEquatable<Option<T>>
 {
-    private Option() : base(new None()) { }
-    private Option(T value) : base(value) { }
+    public Option(T value)
+    {
+        HasValue = true;
+        Value = value;
+    }
+    public Option()
+    {
+        HasValue = false;
+        Value = default;
+    }
 
+    public bool HasValue { get; }
+    public T? Value { get; }
+    public T AsT0 => HasValue ? Value! : throw new InvalidOperationException();
+    
+    public bool IsSome => HasValue;
+    public bool IsNone => !HasValue;
+    
     public static implicit operator Option<T>(T t) => new(t);
     public static implicit operator Option<T>(None _) => new();
-
-    public bool IsSome => IsT0;
-    public bool IsNone => IsT1;
-
-    public Option<TOut> Select<TOut>(Func<T, TOut> mapFn)
+    
+    public bool Equals(Option<T> other) => HasValue == other.HasValue && EqualityComparer<T?>.Default.Equals(Value, other.Value);
+    public override bool Equals(object? obj) => obj is Option<T> other && Equals(other);
+    public override int GetHashCode()
     {
-        return Match(val => new Option<TOut>(mapFn(val)), none => none);
+        unchecked
+        {
+            return (HasValue.GetHashCode() * 397) ^ EqualityComparer<T?>.Default.GetHashCode(Value);
+        }
     }
 
-    public Option<TOut> SelectMany<TOut>(Func<T, Option<TOut>> mapFn)
-    {
-        return Match(mapFn, none => none);
-    }
+    public static bool operator ==(Option<T> left, Option<T> right) => left.Equals(right);
+    public static bool operator !=(Option<T> left, Option<T> right) => !left.Equals(right);
+
+    public Option<TOut> Select<TOut>(Func<T, TOut> mapFn) => HasValue ? new Option<TOut>(mapFn(Value!)) : new Option<TOut>();
+    public Option<TOut> SelectMany<TOut>(Func<T, Option<TOut>> mapFn) => HasValue ? mapFn(Value!) : new Option<TOut>();
+
+    public TResult Match<TResult>(Func<T, TResult> someFn, Func<T?, TResult> noneFn) => HasValue ? someFn(Value!) : noneFn(Value);
 }

--- a/SelectParser/Option.cs
+++ b/SelectParser/Option.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using OneOf.Types;
 
 namespace SelectParser;
 
@@ -39,3 +38,5 @@ public readonly struct Option<T> : IEquatable<Option<T>>
 
     public TResult Match<TResult>(Func<T, TResult> someFn, Func<T?, TResult> noneFn) => HasValue ? someFn(Value!) : noneFn(Value);
 }
+
+public struct None;

--- a/SelectParser/Option.cs
+++ b/SelectParser/Option.cs
@@ -29,13 +29,7 @@ public readonly struct Option<T> : IEquatable<Option<T>>
     
     public bool Equals(Option<T> other) => HasValue == other.HasValue && EqualityComparer<T?>.Default.Equals(Value, other.Value);
     public override bool Equals(object? obj) => obj is Option<T> other && Equals(other);
-    public override int GetHashCode()
-    {
-        unchecked
-        {
-            return (HasValue.GetHashCode() * 397) ^ EqualityComparer<T?>.Default.GetHashCode(Value);
-        }
-    }
+    public override int GetHashCode() => unchecked((HasValue.GetHashCode() * 397) ^ (Value is not null ? EqualityComparer<T?>.Default.GetHashCode(Value) : 0));
 
     public static bool operator ==(Option<T> left, Option<T> right) => left.Equals(right);
     public static bool operator !=(Option<T> left, Option<T> right) => !left.Equals(right);

--- a/SelectParser/Parser.cs
+++ b/SelectParser/Parser.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using OneOf.Types;
 using SelectParser.Queries;
 
 namespace SelectParser;
@@ -450,7 +449,7 @@ public class Parser
             }
             
             case SelectToken.Avg: return SingleParameterFunction(ref tokenizer, x => new AggregateFunction.Average(x));
-            case SelectToken.Count: return SingleParameterFunction(ref tokenizer, x => new AggregateFunction.Count(x.IsT3 && x.AsT3 is { Name: "*" } ? new None() : x));
+            case SelectToken.Count: return SingleParameterFunction(ref tokenizer, x => new AggregateFunction.Count(x is Expression.Identifier { Name: "*" } ? new None() : x));
             case SelectToken.Max: return SingleParameterFunction(ref tokenizer, x => new AggregateFunction.Max(x));
             case SelectToken.Min: return SingleParameterFunction(ref tokenizer, x => new AggregateFunction.Min(x));
             case SelectToken.Sum: return SingleParameterFunction(ref tokenizer, x => new AggregateFunction.Sum(x));
@@ -541,7 +540,7 @@ public class Parser
         if (peekNext.Type == SelectToken.Star)
         {
             tokenizer = peekTokenizer;
-            return Result<SelectClause>.Ok(new SelectClause(new SelectClause.Star()));
+            return Result<SelectClause>.Ok(new SelectClause.Star());
         }
 
         var columns = new List<Column>();
@@ -566,7 +565,7 @@ public class Parser
             tokenizer = peekTokenizer;
         }
 
-        return Result<SelectClause>.Ok(new SelectClause(new SelectClause.List(columns)));
+        return Result<SelectClause>.Ok(new SelectClause.List(columns));
     }
 
     private static Result<Option<string>> Alias(ref SelectTokenizer tokenizer)

--- a/SelectParser/Parser.cs
+++ b/SelectParser/Parser.cs
@@ -1,406 +1,790 @@
 ﻿using System;
-using System.Linq;
-using JetBrains.Annotations;
+using System.Collections.Generic;
 using OneOf.Types;
 using SelectParser.Queries;
-using Superpower;
-using Superpower.Model;
-using Superpower.Parsers;
 
 namespace SelectParser;
 
 public class Parser
 {
-    private static readonly TokenListParser<SelectToken, (string Identifier, bool CaseSensitive)> Identifier =
-        Token.EqualTo(SelectToken.Identifier)
-            .Select(ParseIdentifier);
-
-    private static readonly TokenListParser<SelectToken, decimal> Number =
-        Token.EqualTo(SelectToken.NumberLiteral)
-            .Select(x => decimal.Parse(x.ToStringValue()));
-
-    private static readonly TokenListParser<SelectToken, string> String =
-        Token.EqualTo(SelectToken.StringLiteral)
-            .Select(ParseString);
-
-    private static readonly TokenListParser<SelectToken, bool> Boolean =
-        Token.EqualTo(SelectToken.BooleanLiteral)
-            .Select(x => bool.Parse(x.ToStringValue()));
-
-
-    private static readonly TokenListParser<SelectToken, string> Alias =
-        Token.Sequence(SelectToken.As, SelectToken.Identifier).Select(x => ParseIdentifier(x[1]).Identifier)
-            .Or(Identifier.Select(x => x.Identifier));
-
     #region function
 
-    private static readonly TokenListParser<SelectToken, Function> AvgFunction = SingleParameterFunction(SelectToken.Avg, x => new AggregateFunction.Average(x));
-    private static readonly TokenListParser<SelectToken, Function> CountFunction = SingleParameterFunction(SelectToken.Count, BuildCountFunction);
-    private static readonly TokenListParser<SelectToken, Function> MaxFunction = SingleParameterFunction(SelectToken.Max, x => new AggregateFunction.Max(x));
-    private static readonly TokenListParser<SelectToken, Function> MinFunction = SingleParameterFunction(SelectToken.Min, x => new AggregateFunction.Min(x));
-    private static readonly TokenListParser<SelectToken, Function> SumFunction = SingleParameterFunction(SelectToken.Sum, x => new AggregateFunction.Sum(x));
-
-    private static readonly TokenListParser<SelectToken, Function> AggregateFunction = AvgFunction.Or(CountFunction).Or(MaxFunction).Or(MinFunction).Or(SumFunction);
-
-    private static AggregateFunction BuildCountFunction(Expression expression)
+    private static Result<Expression> SingleParameterFunction(ref SelectTokenizer tokenizer, Func<Expression, AggregateFunction> constructor)
     {
-        if (expression.Value is Expression.Identifier { Name: "*" })
+        var leftBracket = SelectTokenizer.Read(ref tokenizer);
+        if(leftBracket.Type != SelectToken.LeftBracket) return Result<Expression>.UnexpectedToken(leftBracket);
+
+        var argument = Expression(ref tokenizer);
+        if (!argument.Success) return argument;
+        
+        var rightBracket = SelectTokenizer.Read(ref tokenizer);
+        if(rightBracket.Type != SelectToken.RightBracket) return Result<Expression>.UnexpectedToken(rightBracket);
+
+        var result = constructor(argument.Value!);
+        
+        return Result<Expression>.Ok(new Expression.FunctionExpression(result));
+    }
+    
+    #endregion
+    
+    #region expression
+
+    public static Result<Expression> Expression(ref SelectTokenizer tokenizer) => BooleanOr(ref tokenizer);
+    public static Result<Expression> BooleanOr(ref SelectTokenizer tokenizer)
+    {
+        var expr = BooleanAnd(ref tokenizer);
+        if (!expr.Success) return expr;
+        
+        var peekTokenizer = tokenizer;
+        var next = SelectTokenizer.Read(ref peekTokenizer);
+
+        while(next.Type == SelectToken.Or)
         {
-            return new AggregateFunction.Count(new None());
-        }
+            tokenizer = peekTokenizer;
+            var rightExpr = BooleanAnd(ref tokenizer);
+            if (!rightExpr.Success) return rightExpr;
             
-        return new AggregateFunction.Count(expression);
+            expr = Result<Expression>.Ok(new Expression.Binary(BinaryOperator.Or, expr.Value!, rightExpr.Value!)); 
+            
+            peekTokenizer = tokenizer;
+            next = SelectTokenizer.Read(ref peekTokenizer);
+        }
+        
+        return expr;
     }
 
-    private static readonly TokenListParser<SelectToken, Function> ScalarFunction =
-        from name in Token.EqualTo(SelectToken.Identifier)
-        from begin in Token.EqualTo(SelectToken.LeftBracket)
-        from expr in Superpower.Parse.Ref(() => Expression)
-        from end in Token.EqualTo(SelectToken.RightBracket)
-        select (Function) new ScalarFunction(new Expression.Identifier(name.ToStringValue(), false), new [] { expr });
-
-    private static readonly TokenListParser<SelectToken, Function> Function = AggregateFunction.Or(ScalarFunction.Try());
-    private static readonly TokenListParser<SelectToken, Expression> FunctionExpression = Function.Select(x => (Expression) new Expression.FunctionExpression(x));
-
-    private static TokenListParser<SelectToken, Function> SingleParameterFunction(SelectToken nameToken, Func<Expression, AggregateFunction> constructor) => SingleParameterFunction(nameToken, x => (Function) constructor(x));
-    private static TokenListParser<SelectToken, Function> SingleParameterFunction(SelectToken nameToken, Func<Expression, Function> constructor) =>
-        from name in Token.EqualTo(nameToken)
-        from begin in Token.EqualTo(SelectToken.LeftBracket)
-        from expr in Superpower.Parse.Ref(() => Expression)
-        from end in Token.EqualTo(SelectToken.RightBracket)
-        select constructor(expr);
-
-    #endregion
-        
-    #region expression 
-
-    private static readonly TokenListParser<SelectToken, Expression> QualifiedIdentifier =
-        Identifier
-            .Or(Token.EqualTo(SelectToken.Star).Select(_ => ("*", false)))
-            .Select(x => new Expression.Identifier(x.Item1, x.Item2))
-            .AtLeastOnceDelimitedBy(Token.EqualTo(SelectToken.Dot))
-            .Select(BuildQualified);
-    private static Expression BuildQualified(Expression.Identifier[] identifiers)
+    public static Result<Expression> BooleanAnd(ref SelectTokenizer tokenizer)
     {
-        switch (identifiers.Length)
+        var expr = BooleanUnary(ref tokenizer);
+        if (!expr.Success) return expr;
+        
+        var peekTokenizer = tokenizer;
+        var next = SelectTokenizer.Read(ref peekTokenizer);
+
+        while(next.Type == SelectToken.And)
         {
-            case 0: throw new InvalidOperationException("Cannot build a qualified expression from no identifiers");
-            case 1: return identifiers[0];
+            tokenizer = peekTokenizer;
+            var rightExpr = BooleanUnary(ref tokenizer);
+            if (!rightExpr.Success) return rightExpr;
+            
+            expr = Result<Expression>.Ok(new Expression.Binary(BinaryOperator.And, expr.Value!, rightExpr.Value!)); 
+            
+            peekTokenizer = tokenizer;
+            next = SelectTokenizer.Read(ref peekTokenizer);
+        }
+        
+        return expr;
+    }
+
+    public static Result<Expression> BooleanUnary(ref SelectTokenizer tokenizer)
+    {
+        var peekTokenizer = tokenizer;
+        var next = SelectTokenizer.Read(ref peekTokenizer);
+
+        if (next.Type == SelectToken.Not)
+        {
+            tokenizer = peekTokenizer;
+            var term = Equality(ref tokenizer);
+            if (!term.Success) return term;
+            
+            return Result<Expression>.Ok(new Expression.Unary(UnaryOperator.Not, term.Value!));
         }
 
-        Expression result = identifiers[identifiers.Length - 1];
-        for (var i = identifiers.Length - 2; i >= 0; i--)
+        return Equality(ref tokenizer);
+    }
+
+    public static Result<Expression> Equality(ref SelectTokenizer tokenizer)
+    {
+        var expr = Comparative(ref tokenizer);
+        if (!expr.Success) return expr;
+
+        var peekTokenizer = tokenizer;
+        var next = SelectTokenizer.Read(ref peekTokenizer);
+
+        while(next.Type is SelectToken.Equal or SelectToken.NotEqual)
+        {
+            tokenizer = peekTokenizer;
+            var rightExpr = Comparative(ref tokenizer);
+            if (!rightExpr.Success) return rightExpr;
+
+            var op = next.Type switch
+            {
+                SelectToken.Equal => BinaryOperator.Equal,
+                SelectToken.NotEqual => BinaryOperator.NotEqual,
+            };
+            
+            expr = Result<Expression>.Ok(new Expression.Binary(op, expr.Value!, rightExpr.Value!)); 
+            
+            peekTokenizer = tokenizer;
+            next = SelectTokenizer.Read(ref peekTokenizer);
+        }
+
+        return expr;
+    }
+
+    public static Result<Expression> Comparative(ref SelectTokenizer tokenizer)
+    {
+        var expr = StringConcatenation(ref tokenizer);
+        if (!expr.Success) return expr;
+
+        var peekTokenizer = tokenizer;
+        var next = SelectTokenizer.Read(ref peekTokenizer);
+
+        if (next.Type is SelectToken.Lesser or SelectToken.LesserOrEqual or SelectToken.Greater or SelectToken.GreaterOrEqual)
+        {
+            tokenizer = peekTokenizer;
+
+            var rightExpr = StringConcatenation(ref tokenizer);
+            if (!rightExpr.Success) return rightExpr;
+
+            var op = next.Type switch
+            {
+                SelectToken.Lesser => BinaryOperator.Lesser,
+                SelectToken.LesserOrEqual => BinaryOperator.LesserOrEqual,
+                SelectToken.Greater => BinaryOperator.Greater,
+                SelectToken.GreaterOrEqual => BinaryOperator.GreaterOrEqual,
+            };
+            
+            expr = Result<Expression>.Ok(new Expression.Binary(op, expr.Value!, rightExpr.Value!));
+        }
+
+        return expr;
+    }
+
+    public static Result<Expression> StringConcatenation(ref SelectTokenizer tokenizer)
+    {
+        var expr = Pattern(ref tokenizer);
+        if (!expr.Success) return expr;
+
+        var peekTokenizer = tokenizer;
+        var next = SelectTokenizer.Read(ref peekTokenizer);
+
+        if (next.Type is SelectToken.Concat)
+        {
+            tokenizer = peekTokenizer;
+
+            var rightExpr = Pattern(ref tokenizer);
+            if (!rightExpr.Success) return rightExpr;
+            
+            expr = Result<Expression>.Ok(new Expression.Binary(BinaryOperator.Concat, expr.Value!, rightExpr.Value!));
+        }
+
+        return expr;
+    }
+    
+    public static Result<Expression> Pattern(ref SelectTokenizer tokenizer)
+    {
+        var expr = Containment(ref tokenizer);
+        if (!expr.Success) return expr;
+
+        var peekTokenizer = tokenizer;
+        var peekNext = SelectTokenizer.Read(ref peekTokenizer);
+        
+        if (peekNext.Type != SelectToken.Like)
+        {
+            return expr;
+        }
+
+        tokenizer = peekTokenizer;
+
+        var pattern = Expression(ref tokenizer);
+        if (!pattern.Success) return pattern;
+        
+        peekTokenizer = tokenizer;
+        peekNext = SelectTokenizer.Read(ref peekTokenizer);
+        
+        if (peekNext.Type != SelectToken.Escape)
+        {
+            return Result<Expression>.Ok(new Expression.Like(expr.Value!, pattern.Value!, new Option<Expression>()));
+        }
+
+        tokenizer = peekTokenizer;
+
+        var escape = Expression(ref tokenizer);
+        if (!escape.Success) return escape;
+        
+        return Result<Expression>.Ok(new Expression.Like(expr.Value!, pattern.Value!, escape.Value!));
+    }
+
+    public static Result<Expression> Containment(ref SelectTokenizer tokenizer)
+    {
+        var expr = Presence(ref tokenizer);
+        if (!expr.Success) return expr;
+
+        var peekTokenizer = tokenizer;
+        var next = SelectTokenizer.Read(ref peekTokenizer);
+
+        var negate = next.Type is SelectToken.Not;
+        if (negate)
+        {
+            next = SelectTokenizer.Read(ref peekTokenizer);
+        }
+        
+        if (next.Type != SelectToken.Between)
+        {
+            // don't accept peek tokenizer
+            return expr;
+        }
+
+        tokenizer = peekTokenizer;
+        
+        var lower = Presence(ref tokenizer);
+        if (!lower.Success) return lower;
+
+        next = SelectTokenizer.Read(ref tokenizer);
+        if(next.Type != SelectToken.And) return Result<Expression>.UnexpectedToken(next);
+        
+        var upper = Expression(ref tokenizer);
+        if (!upper.Success) return upper;
+        
+        return Result<Expression>.Ok(new Expression.Between(negate, expr.Value!, lower.Value!, upper.Value!));
+    }
+
+    public static Result<Expression> Presence(ref SelectTokenizer tokenizer)
+    {
+        var expr = IsNull(ref tokenizer);
+        if (!expr.Success) return expr;
+
+        var peekTokenizer = tokenizer;
+        var next = SelectTokenizer.Read(ref peekTokenizer);
+
+        if (next.Type != SelectToken.Is)
+        {
+            return expr;
+        }
+        
+        next = SelectTokenizer.Read(ref peekTokenizer);
+
+        var negate = next.Type is SelectToken.Not;
+        if (negate)
+        {
+            next = SelectTokenizer.Read(ref peekTokenizer);
+        }
+
+        if (next.Type != SelectToken.Missing)
+        {
+            // don't accept peek tokenizer
+            return expr;
+        }
+
+        tokenizer = peekTokenizer;
+        return Result<Expression>.Ok(new Expression.Presence(expr.Value!, !negate));
+    }
+
+    public static Result<Expression> IsNull(ref SelectTokenizer tokenizer)
+    {
+        var expr = Membership(ref tokenizer);
+        if (!expr.Success) return expr;
+
+        var peekTokenizer = tokenizer;
+        var next = SelectTokenizer.Read(ref peekTokenizer);
+
+        if (next.Type != SelectToken.Is)
+        {
+            return expr;
+        }
+        
+        next = SelectTokenizer.Read(ref peekTokenizer);
+
+        var negate = next.Type is SelectToken.Not;
+        if (negate)
+        {
+            next = SelectTokenizer.Read(ref peekTokenizer);
+        }
+
+        if (next.Type != SelectToken.Null)
+        {
+            // don't accept peek tokenizer
+            return expr;
+        }
+
+        tokenizer = peekTokenizer;
+        return Result<Expression>.Ok(new Expression.IsNull(expr.Value!, negate));
+    }
+
+    public static Result<Expression> Membership(ref SelectTokenizer tokenizer)
+    {
+        var expr = Additive(ref tokenizer);
+        if (!expr.Success) return expr;
+
+        var peekTokenizer = tokenizer;
+        var next = SelectTokenizer.Read(ref peekTokenizer);
+
+        if (next.Type != SelectToken.In)
+        {
+            return expr;
+        }
+
+        tokenizer = peekTokenizer;
+
+        next = SelectTokenizer.Read(ref tokenizer);
+        if(next.Type != SelectToken.LeftBracket) return Result<Expression>.UnexpectedToken(next);
+
+        var values = new List<Expression>();
+        while (true)
+        {
+            var value = Expression(ref tokenizer);
+            if (!value.Success) return expr;
+
+            values.Add(value.Value!);
+            
+            next = SelectTokenizer.Read(ref tokenizer);
+            if (next.Type == SelectToken.RightBracket) break;
+            if (next.Type != SelectToken.Comma) return Result<Expression>.UnexpectedToken(next);
+        }
+        
+        return Result<Expression>.Ok(new Expression.In(expr.Value!, values));
+    }
+
+    public static Result<Expression> Additive(ref SelectTokenizer tokenizer)
+    {
+        var expr = Multiplicative(ref tokenizer);
+        if (!expr.Success) return expr;
+        
+        var peekTokenizer = tokenizer;
+        var next = SelectTokenizer.Read(ref peekTokenizer);
+
+        while(next.Type is SelectToken.Add or SelectToken.Negate)
+        {
+            tokenizer = peekTokenizer;
+            var rightExpr = Multiplicative(ref tokenizer);
+            if (!rightExpr.Success) return rightExpr;
+
+            var op = next.Type switch
+            {
+                SelectToken.Add => BinaryOperator.Add,
+                SelectToken.Negate => BinaryOperator.Subtract,
+            };
+            
+            expr = Result<Expression>.Ok(new Expression.Binary(op, expr.Value!, rightExpr.Value!)); 
+            
+            peekTokenizer = tokenizer;
+            next = SelectTokenizer.Read(ref peekTokenizer);
+        }
+        
+        return expr;
+    }
+
+    public static Result<Expression> Multiplicative(ref SelectTokenizer tokenizer)
+    {
+        var expr = Unary(ref tokenizer);
+        if (!expr.Success) return expr;
+        
+        var peekTokenizer = tokenizer;
+        var next = SelectTokenizer.Read(ref peekTokenizer);
+
+        while(next.Type is SelectToken.Star or SelectToken.Divide or SelectToken.Modulo)
+        {
+            tokenizer = peekTokenizer;
+            var rightExpr = Unary(ref tokenizer);
+            if (!rightExpr.Success) return rightExpr;
+
+            var op = next.Type switch
+            {
+                SelectToken.Star => BinaryOperator.Multiply,
+                SelectToken.Divide => BinaryOperator.Divide,
+                SelectToken.Modulo => BinaryOperator.Modulo,
+            };
+            
+            expr = Result<Expression>.Ok(new Expression.Binary(op, expr.Value!, rightExpr.Value!)); 
+            
+            peekTokenizer = tokenizer;
+            next = SelectTokenizer.Read(ref peekTokenizer);
+        }
+        
+        return expr;
+    }
+
+    public static Result<Expression> Unary(ref SelectTokenizer tokenizer)
+    {
+        var peekTokenizer = tokenizer;
+        var next = SelectTokenizer.Read(ref peekTokenizer);
+
+        if (next.Type == SelectToken.Negate)
+        {
+            tokenizer = peekTokenizer;
+            var term = Term(ref tokenizer);
+            if (!term.Success) return term;
+            
+            return Result<Expression>.Ok(new Expression.Unary(UnaryOperator.Negate, term.Value!));
+        }
+
+        return Term(ref tokenizer);
+    }
+
+    public static Result<Expression> Term(ref SelectTokenizer tokenizer)
+    {
+        var next = SelectTokenizer.Read(ref tokenizer);
+
+        switch (next.Type)
+        {
+            case SelectToken.NumberLiteral: return Result<Expression>.Ok(new Expression.NumberLiteral(ParseNumber(next)));
+            case SelectToken.StringLiteral: return Result<Expression>.Ok(new Expression.StringLiteral(ParseString(next)));
+            case SelectToken.BooleanLiteral: return Result<Expression>.Ok(new Expression.BooleanLiteral(bool.Parse(next.ToStringValue())));
+            case SelectToken.Identifier:
+            {
+                var identifier = ParseIdentifier(next);
+                return QualifiedIdentifier(ref tokenizer, identifier);
+            }
+            case SelectToken.Star: return Result<Expression>.Ok(new Expression.Identifier("*", false));
+            case SelectToken.LeftBracket:
+            {
+                var expr = Expression(ref tokenizer);
+                
+                next = SelectTokenizer.Read(ref tokenizer);
+                if (next.Type != SelectToken.RightBracket)
+                {
+                    return Result<Expression>.UnexpectedToken(next);
+                }
+
+                return expr;
+            }
+            
+            case SelectToken.Avg: return SingleParameterFunction(ref tokenizer, x => new AggregateFunction.Average(x));
+            case SelectToken.Count: return SingleParameterFunction(ref tokenizer, x => new AggregateFunction.Count(x.IsT3 && x.AsT3 is { Name: "*" } ? new None() : x));
+            case SelectToken.Max: return SingleParameterFunction(ref tokenizer, x => new AggregateFunction.Max(x));
+            case SelectToken.Min: return SingleParameterFunction(ref tokenizer, x => new AggregateFunction.Min(x));
+            case SelectToken.Sum: return SingleParameterFunction(ref tokenizer, x => new AggregateFunction.Sum(x));
+
+            default: return Result<Expression>.UnexpectedToken(next);
+        }
+    }
+    
+    private static Result<Expression> QualifiedIdentifier(ref SelectTokenizer tokenizer, Expression.Identifier initial)
+    {
+        var peekTokenizer = tokenizer;
+        var next = SelectTokenizer.Read(ref peekTokenizer);
+
+        if (next.Type == SelectToken.LeftBracket)
+        {
+            // scalar function
+            tokenizer = peekTokenizer;
+
+            var expr = Expression(ref tokenizer);
+            if (!expr.Success) return expr;
+            
+            next = SelectTokenizer.Read(ref tokenizer);
+            if(next.Type != SelectToken.RightBracket) return Result<Expression>.UnexpectedToken(next);
+            
+            return Result<Expression>.Ok(new Expression.FunctionExpression(new ScalarFunction(initial, new [] { expr.Value! })));
+        }
+        
+        if (next.Type != SelectToken.Dot)
+        {
+            return Result<Expression>.Ok(initial);
+        }
+        
+        var identifiers = new List<Expression.Identifier>
+        {
+            initial
+        };
+
+        tokenizer = peekTokenizer;
+        while (true)
+        {
+            next = SelectTokenizer.Read(ref tokenizer);
+
+            if (next.Type == SelectToken.Star)
+            {
+                identifiers.Add(new Expression.Identifier("*", false));
+                break;
+            }
+            
+            if (next.Type != SelectToken.Identifier)
+            {
+                return Result<Expression>.UnexpectedToken(next);
+            }
+
+            identifiers.Add(ParseIdentifier(next));
+            
+            peekTokenizer = tokenizer;
+            next = SelectTokenizer.Read(ref peekTokenizer);
+
+            if (next.Type != SelectToken.Dot)
+            {
+                break;
+            }
+            
+            tokenizer = peekTokenizer;
+        }
+        
+        Expression result = identifiers[identifiers.Count - 1];
+        for (var i = identifiers.Count - 2; i >= 0; i--)
         {
             result = new Expression.Qualified(identifiers[i], result);
         }
+        
+        return Result<Expression>.Ok(result);
+    }
+
+    #endregion
+    
+    #region select
+    
+    public static Result<SelectClause> SelectClause(ref SelectTokenizer tokenizer)
+    {
+        var next = SelectTokenizer.Read(ref tokenizer);
+        if (next.Type != SelectToken.Select) return Result<SelectClause>.UnexpectedToken(next);
+        
+        var peekTokenizer = tokenizer;
+        var peekNext = SelectTokenizer.Read(ref peekTokenizer);
+
+        if (peekNext.Type == SelectToken.Star)
+        {
+            tokenizer = peekTokenizer;
+            return Result<SelectClause>.Ok(new SelectClause(new SelectClause.Star()));
+        }
+
+        var columns = new List<Column>();
+        while (true)
+        {
+            var expression = Expression(ref tokenizer);
+            if(!expression.Success) return Result<SelectClause>.FromError(expression);
+            
+            var alias = Alias(ref tokenizer);
+            if(!alias.Success) return Result<SelectClause>.FromError(expression);
+
+            columns.Add(new Column(expression.Value!, alias.Value));
+            
+            peekTokenizer = tokenizer;
+            peekNext = SelectTokenizer.Read(ref peekTokenizer);
+
+            if (peekNext.Type != SelectToken.Comma)
+            {
+                break;
+            }
+
+            tokenizer = peekTokenizer;
+        }
+
+        return Result<SelectClause>.Ok(new SelectClause(new SelectClause.List(columns)));
+    }
+
+    private static Result<Option<string>> Alias(ref SelectTokenizer tokenizer)
+    {
+        var peekTokenizer = tokenizer;
+        var peekNext = SelectTokenizer.Read(ref peekTokenizer);
+
+        switch (peekNext.Type)
+        {
+            case SelectToken.As:
+            {
+                tokenizer = peekTokenizer;
+            
+                var next = SelectTokenizer.Read(ref tokenizer);
+                if (next.Type != SelectToken.Identifier) return Result<Option<string>>.UnexpectedToken(next);
+
+                return Result<Option<string>>.Ok(ParseIdentifier(next).Name);
+            }
+            
+            case SelectToken.Identifier:
+                tokenizer = peekTokenizer;
+                return Result<Option<string>>.Ok(ParseIdentifier(peekNext).Name);
+            
+            default:
+                return Result<Option<string>>.Ok(new Option<string>());
+        }
+    }
+    
+    #endregion
+    
+    #region from
+
+    public static Result<FromClause> FromClause(ref SelectTokenizer tokenizer)
+    {
+        var next = SelectTokenizer.Read(ref tokenizer);
+        if (next.Type != SelectToken.From) return Result<FromClause>.UnexpectedToken(next);
+
+        next = SelectTokenizer.Read(ref tokenizer);
+        if (next.Type != SelectToken.Identifier) return Result<FromClause>.UnexpectedToken(next);
+        var tableName = ParseIdentifier(next);
+        
+        var alias = Alias(ref tokenizer);
+        if (!alias.Success) return Result<FromClause>.FromError(alias);
+        
+        return Result<FromClause>.Ok(new FromClause(tableName.Name, alias.Value));
+    }
+    
+    #endregion
+    
+    #region where
+    
+    public static Result<WhereClause?> WhereClause(ref SelectTokenizer tokenizer)
+    {
+        var peekTokenizer = tokenizer;
+        var peekNext = SelectTokenizer.Read(ref peekTokenizer);
+        if (peekNext.Type != SelectToken.Where) return Result<WhereClause?>.Ok(null);
+
+        tokenizer = peekTokenizer;
+        
+        var expr = Expression(ref tokenizer);
+        if (!expr.Success) return Result<WhereClause?>.FromError(expr);
+        
+        return Result<WhereClause?>.Ok(new WhereClause(expr.Value!));
+    }
+
+    #endregion
+    
+    #region order by
+    
+    public static Result<OrderClause?> OrderByClause(ref SelectTokenizer tokenizer)
+    {
+        var peekTokenizer = tokenizer;
+        var peekNext = SelectTokenizer.Read(ref peekTokenizer);
+        if (peekNext.Type != SelectToken.Order) return Result<OrderClause?>.Ok(null);
+        
+        tokenizer = peekTokenizer;
+
+        var next = SelectTokenizer.Read(ref tokenizer);
+        if (next.Type != SelectToken.By) return Result<OrderClause?>.UnexpectedToken(next);
+
+        var columns = new List<(Expression, OrderDirection)>();
+        
+        while (true)
+        {
+            var expr = Expression(ref tokenizer);
+            if (!expr.Success) return Result<OrderClause?>.FromError(expr);
+
+            peekTokenizer = tokenizer;
+            peekNext = SelectTokenizer.Read(ref peekTokenizer);
+
+            var order = OrderDirection.Ascending;
+            switch (peekNext.Type)
+            {
+                case SelectToken.Asc:
+                    tokenizer = peekTokenizer;
+
+                    order = OrderDirection.Ascending;
+                    peekNext = SelectTokenizer.Read(ref peekTokenizer);
+                    break;
+                case SelectToken.Desc:
+                    tokenizer = peekTokenizer;
+
+                    order = OrderDirection.Descending;
+                    peekNext = SelectTokenizer.Read(ref peekTokenizer);
+                    break;
+            }
+            
+            columns.Add((expr.Value!, order));
+
+            if (peekNext.Type == SelectToken.Comma)
+            {
+                tokenizer = peekTokenizer;
+            }
+            else
+            {
+                break;
+            }
+        }
+        
+        return Result<OrderClause?>.Ok(new OrderClause(columns));
+    }
+
+    #endregion
+    
+    #region limit
+    
+    public static Result<LimitClause?> LimitClause(ref SelectTokenizer tokenizer)
+    {
+        var peekTokenizer = tokenizer;
+        var peekNext = SelectTokenizer.Read(ref peekTokenizer);
+        if (peekNext.Type != SelectToken.Limit) return Result<LimitClause?>.Ok(null);
+        
+        tokenizer = peekTokenizer;
+        
+        var next = SelectTokenizer.Read(ref tokenizer);
+        if(next.Type != SelectToken.NumberLiteral) return Result<LimitClause?>.UnexpectedToken(next);
+
+        var limit = ParseNumber(next);
+        
+        return Result<LimitClause?>.Ok(new LimitClause((int)limit));
+    }
+
+    #endregion
+    
+    public static Result<Query> Parse(string query)
+    {
+        var tokenizer = new SelectTokenizer(query.AsSpan());
+        var result = Query(ref tokenizer);
+        if (!result.Success)
+        {
+            return result;
+        }
+
+        var final = SelectTokenizer.Read(ref tokenizer);
+        if (final.Type != SelectToken.Eof)
+        {
+            return Result<Query>.UnexpectedToken(final);
+        }
+
         return result;
     }
-
-    public static readonly TokenListParser<SelectToken, Expression> BracketExpression =
-        from begin in Token.EqualTo(SelectToken.LeftBracket)
-        from expr in Superpower.Parse.Ref(() => Expression)
-        from end in Token.EqualTo(SelectToken.RightBracket)
-        select expr;
-
-    public static readonly TokenListParser<SelectToken, Expression> Term =
-        FunctionExpression
-            .Or(QualifiedIdentifier)
-            .Or(Number.Select(x => (Expression)new Expression.NumberLiteral(x)))
-            .Or(String.Select(x => (Expression)new Expression.StringLiteral(x)))
-            .Or(Boolean.Select(x => (Expression)new Expression.BooleanLiteral(x)))
-            .Or(BracketExpression);
-
-    public static readonly TokenListParser<SelectToken, Expression> Unary =
-        (
-            from op in Token.EqualTo(SelectToken.Negate)
-            from term in Term
-            select (Expression)new Expression.Unary(UnaryOperator.Negate, term)
-        )
-        .Or(Term);
-
-    public static readonly TokenListParser<SelectToken, Expression> Multiplicative =
-        Superpower.Parse.Chain(
-            Token.EqualTo(SelectToken.Star).Or(Token.EqualTo(SelectToken.Divide)).Or(Token.EqualTo(SelectToken.Modulo)),
-            Unary,
-            CreateMultiplicative
-        );
-    private static Expression CreateMultiplicative(Token<SelectToken> opToken, Expression left, Expression right)
-    {
-        var operation = opToken.Kind switch
-        {
-            SelectToken.Star => BinaryOperator.Multiply,
-            SelectToken.Divide => BinaryOperator.Divide,
-            SelectToken.Modulo => BinaryOperator.Modulo,
-                
-            _ => throw new InvalidOperationException("Operation should be a multiplicative token")
-        };
-
-        return new Expression.Binary(operation, left, right);
-    }
-
-    public static readonly TokenListParser<SelectToken, Expression> Additive =
-        Superpower.Parse.Chain(
-            Token.EqualTo(SelectToken.Add).Or(Token.EqualTo(SelectToken.Negate)),
-            Multiplicative,
-            CreateAdditive
-        );
-    private static Expression CreateAdditive(Token<SelectToken> opToken, Expression left, Expression right)
-    {
-        var operation = opToken.Kind switch
-        {
-            SelectToken.Add => BinaryOperator.Add,
-            SelectToken.Negate => BinaryOperator.Subtract,
-                
-            _ => throw new InvalidOperationException("Operation should be a additive token")
-        };
-
-        return new Expression.Binary(operation, left, right);
-    }
-
-    public static readonly TokenListParser<SelectToken, Expression> Membership = ParseOptionalOrDefaultSuffix(
-        Additive,
-        (
-            from @in in Token.EqualTo(SelectToken.In)
-            from begin in Token.EqualTo(SelectToken.LeftBracket)
-            from values in Superpower.Parse.Ref(() => Expression).ManyDelimitedBy(
-                Token.EqualTo(SelectToken.Comma),
-                Token.EqualTo(SelectToken.RightBracket))
-            select values
-        ),
-        (expr, suffix) => new Expression.In(expr, suffix)
-    );
-
-    public static readonly TokenListParser<SelectToken, Expression> IsNull = ParseOptionalSuffix(
-        Membership,
-        (
-            from @is in Token.EqualTo(SelectToken.Is)
-            from not in Token.EqualTo(SelectToken.Not).Optional()
-            from @null in Token.EqualTo(SelectToken.Null)
-            select not.HasValue
-        ),
-        (expr, suffix) => new Expression.IsNull(expr, suffix)
-    );
-
-    public static readonly TokenListParser<SelectToken, Expression> Presence = ParseOptionalSuffix(
-        IsNull,
-        (
-            from @is in Token.EqualTo(SelectToken.Is)
-            from not in Token.EqualTo(SelectToken.Not).Optional()
-            from missing in Token.EqualTo(SelectToken.Missing)
-            select not.HasValue
-        ),
-        (expr, suffix) => new Expression.Presence(expr, !suffix)
-    );
-
-    public static readonly TokenListParser<SelectToken, Expression> Containment = ParseOptionalSuffix(
-        Presence,
-        (
-            from not in Token.EqualTo(SelectToken.Not).Optional()
-            from between in Token.EqualTo(SelectToken.Between)
-            from lower in Presence
-            from and in Token.EqualTo(SelectToken.And)
-            from upper in Superpower.Parse.Ref(() => Expression)
-            select (negate: not.HasValue, lower, upper)
-        ),
-        (expr, suffix) => new Expression.Between(suffix.negate, expr, suffix.lower, suffix.upper)
-    );
-
-    private static readonly TokenListParser<SelectToken, (Expression Pattern, Option<Expression> Escape)> PatternSuffix = ParseOptionalOrDefaultSuffix(
-        (
-            from between in Token.EqualTo(SelectToken.Like)
-            from pattern in Superpower.Parse.Ref(() => Expression)
-            select (pattern, (Option<Expression>)new None())
-        ),
-        (
-            from escape in Token.EqualTo(SelectToken.Escape)
-            from escapeExpression in Superpower.Parse.Ref(() => Expression)
-            select escapeExpression
-        ),
-        (pattern, escape) => (pattern.pattern, escape)
-    );
-
-    public static readonly TokenListParser<SelectToken, Expression> Pattern = ParseOptionalSuffix(
-        Containment,
-        PatternSuffix,
-        (expr, suffix) => new Expression.Like(expr, suffix.Pattern, suffix.Escape)
-    );
     
-    public static readonly TokenListParser<SelectToken, Expression> StringConcatenation =
-        Superpower.Parse.ChainRight(
-            Token.EqualTo(SelectToken.Concat),
-            Pattern,
-            (_, left, right) => new Expression.Binary(BinaryOperator.Concat, left, right)
-        );
-
-
-    public static readonly TokenListParser<SelectToken, Expression> Comparative = ParseOptionalSuffix(
-        StringConcatenation,
-        (
-            from operation in Token.EqualTo(SelectToken.Lesser).Or(Token.EqualTo(SelectToken.Greater)).Or(Token.EqualTo(SelectToken.LesserOrEqual)).Or(Token.EqualTo(SelectToken.GreaterOrEqual))
-            from right in StringConcatenation
-            select (operation, right)
-        ),
-        (expr, suffix) => new Expression.Binary(GetComparativeOperation(suffix.operation), expr, suffix.right)
-    );
-    private static BinaryOperator GetComparativeOperation(Token<SelectToken> operation) => operation.Kind switch
+    public static Result<Query> Query(ref SelectTokenizer tokenizer)
     {
-        SelectToken.Lesser => BinaryOperator.Lesser,
-        SelectToken.Greater => BinaryOperator.Greater,
-        SelectToken.LesserOrEqual => BinaryOperator.LesserOrEqual,
-        SelectToken.GreaterOrEqual => BinaryOperator.GreaterOrEqual,
-            
-        _ => throw new InvalidOperationException("Operation should be a comparative token")
-    };
-
-    public static readonly TokenListParser<SelectToken, Expression> Equality =
-        Superpower.Parse.ChainRight(
-            Token.EqualTo(SelectToken.Equal).Or(Token.EqualTo(SelectToken.NotEqual)),
-            Comparative,
-            CreateEquality
-        );
-    private static Expression CreateEquality(Token<SelectToken> opToken, Expression left, Expression right)
-    {
-        var operation = opToken.Kind switch
-        {
-            SelectToken.Equal => BinaryOperator.Equal,
-            SelectToken.NotEqual => BinaryOperator.NotEqual,
-                
-            _ => throw new InvalidOperationException("Operation should be a equality token")
-        };
-
-        return new Expression.Binary(operation, left, right);
-    }
-
-    public static readonly TokenListParser<SelectToken, Expression> BooleanUnary =
-    (
-        from operation in Token.EqualTo(SelectToken.Not)
-        from expression in Equality
-        select (Expression)new Expression.Unary(UnaryOperator.Not, expression)
-    ).Or(Equality);
-
-    public static readonly TokenListParser<SelectToken, Expression> BooleanAnd =
-        Superpower.Parse.ChainRight(
-            Token.EqualTo(SelectToken.And),
-            BooleanUnary,
-            (_, left, right) => new Expression.Binary(BinaryOperator.And, left, right)
-        );
-
-    public static readonly TokenListParser<SelectToken, Expression> BooleanOr =
-        Superpower.Parse.ChainRight(
-            Token.EqualTo(SelectToken.Or),
-            BooleanAnd,
-            (_, left, right) => new Expression.Binary(BinaryOperator.Or, left, right)
-        );
-    
-    public static readonly TokenListParser<SelectToken, Expression> Expression = BooleanOr;
-
-    // TODO handle brackets
-
-    #endregion
-
-    #region select
-    private static readonly TokenListParser<SelectToken, Column> Column =
-        from expr in Expression
-        from alias in Alias.Select(x => (Option<string>)x).OptionalOrDefault(new None())
-        select new Column(expr, alias);
-    private static readonly TokenListParser<SelectToken, SelectClause> ColumnsStar =
-        Token.EqualTo(SelectToken.Star).Select(_ => (SelectClause)new SelectClause.Star());
-    private static readonly TokenListParser<SelectToken, SelectClause> ColumnsList =
-        Superpower.Parse.Chain(Token.EqualTo(SelectToken.Comma), Column.Select(x => new SelectClause.List(new[] { x })), CombineColumnLists)
-            .Select(x => (SelectClause)x);
-
-    private static SelectClause.List CombineColumnLists(Token<SelectToken> op, SelectClause.List left, SelectClause.List right)
-    {
-        var columns = left.Columns.Concat(right.Columns).ToList();
-        return new SelectClause.List(columns);
-    }
-
-    public static readonly TokenListParser<SelectToken, SelectClause> SelectClause =
-        from @select in Token.EqualTo(SelectToken.Select)
-        from columns in ColumnsStar.Or(ColumnsList)
-        select columns;
-
-    #endregion
-
-    #region from
-    public static readonly TokenListParser<SelectToken, FromClause> FromClause =
-        from @from in Token.EqualTo(SelectToken.From)
-        from tableName in Identifier.Select(x => x.Identifier)
-        from alias in Alias.Select(x => (Option<string>)x).OptionalOrDefault(new None())
-        select new FromClause(tableName, alias);
-    #endregion
-
-    #region where
-    public static readonly TokenListParser<SelectToken, WhereClause> WhereClause =
-        from @where in Token.EqualTo(SelectToken.Where)
-        from expression in Expression
-        select new WhereClause(expression);
-    #endregion
-
-    #region order by
-
-    private static readonly TokenListParser<SelectToken, (Expression Expression, OrderDirection Direction)> OrderByColumn =
-        from column in Expression
-        from direction in Token.EqualTo(SelectToken.Asc).Select(_ => OrderDirection.Ascending)
-            .Or(Token.EqualTo(SelectToken.Desc).Select(_ => OrderDirection.Descending)).OptionalOrDefault(OrderDirection.Ascending)
-        select (column, direction);
-
-    public static readonly TokenListParser<SelectToken, OrderClause> OrderByClause =
-        from orderBy in Token.Sequence(SelectToken.Order, SelectToken.By)
-        from columns in OrderByColumn.ManyDelimitedBy(Token.EqualTo(SelectToken.Comma))
-        select new OrderClause(columns);
-
-    #endregion
-
-    #region limit
-    public static readonly TokenListParser<SelectToken, LimitClause> LimitClause =
-        from limit in Token.EqualTo(SelectToken.Limit)
-        from number in Number.Select(x => (int)x)
-        select new LimitClause(number);
-    #endregion
+        var select = SelectClause(ref tokenizer);
+        if (!select.Success) return Result<Query>.FromError(select);
         
-    public static readonly TokenListParser<SelectToken, Query> Query =
-        from @select in SelectClause
-        from @from in FromClause
-        from @where in WhereClause.Select(x => (Option<WhereClause>)x).OptionalOrDefault(new None())
-        from order in OrderByClause.Select(x => (Option<OrderClause>)x).OptionalOrDefault(new None())
-        from limit in LimitClause.Select(x => (Option<LimitClause>)x).OptionalOrDefault(new None())
-        select new Query(@select, @from, @where, order, limit);
-    
-    [PublicAPI]
-    public static TokenListParserResult<SelectToken, Query> Parse(string input)
-    {
-        var tokenizer = new SelectTokenizer();
-        var tokens = tokenizer.Tokenize(input);
-        return Parse(tokens);
-    }
-    [PublicAPI]
-    public static TokenListParserResult<SelectToken, Query> Parse(TokenList<SelectToken> input) => Query(input);
+        var from = FromClause(ref tokenizer);
+        if (!from.Success) return Result<Query>.FromError(from);
 
-    private static (string Identifier, bool CaseSensitive) ParseIdentifier(Token<SelectToken> token)
-    {
-        var rawValue = token.ToStringValue();
+        var where = WhereClause(ref tokenizer);
+        if (!where.Success) return Result<Query>.FromError(where);
 
-        return rawValue[0] == '\"'
-            ? (rawValue.Substring(1, rawValue.Length - 2), true)
-            : (rawValue, false);
+        var order = OrderByClause(ref tokenizer);
+        if (!order.Success) return Result<Query>.FromError(order);
+
+        var limit = LimitClause(ref tokenizer);
+        if (!limit.Success) return Result<Query>.FromError(limit);
+
+        var final = SelectTokenizer.Read(ref tokenizer);
+        if(final.Type != SelectToken.Eof) return Result<Query>.UnexpectedToken(final);
+        
+        var query = new Query(select.Value!, from.Value!, where.Value ?? new Option<WhereClause>(), order.Value ?? new Option<OrderClause>(), limit.Value ?? new Option<LimitClause>());
+        
+        return Result<Query>.Ok(query);
     }
 
-    private static string ParseString(Token<SelectToken> token)
+    private static decimal ParseNumber(SelectTokenizer.Token next) => decimal.Parse(next.ToStringValue());
+    private static string ParseString(SelectTokenizer.Token token)
     {
-        var rawValue = token.ToStringValue();
         // TODO handle escapes
-        return rawValue.Substring(1, rawValue.Length - 2);
+        return new string(token.Span.Slice(1, token.Span.Length - 2).ToArray());
     }
-
-    private static TokenListParser<SelectToken, T1> ParseOptionalSuffix<T1, T2>(TokenListParser<SelectToken, T1> expressionParser, TokenListParser<SelectToken, T2> suffixParser, Func<T1, T2, T1> selector) where T2 : struct =>
-        from expression in expressionParser
-        from suffix in suffixParser.Try().Optional()
-        select suffix.HasValue ? selector(expression, suffix.Value) : expression;
+    private static Expression.Identifier ParseIdentifier(SelectTokenizer.Token token)
+    {
+        if (token.Span[0] == '"')
+        {
+            return new Expression.Identifier(new string(token.Span.Slice(1, token.Span.Length - 2).ToArray()), true);
+        }
+        else
+        {
+            return new Expression.Identifier(new string(token.Span.ToArray()), false);
+        }
+    }
     
-    private static TokenListParser<SelectToken, T1> ParseOptionalOrDefaultSuffix<T1, T2>(TokenListParser<SelectToken, T1> expressionParser, TokenListParser<SelectToken, T2> suffixParser, Func<T1, T2, T1> selector) where T2 : class =>
-        from expression in expressionParser
-        from suffix in suffixParser.Try().OptionalOrDefault()
-        select suffix != default ? selector(expression, suffix) : expression;
+    public readonly struct Result<T>
+    {
+        public bool Success { get; }
+        
+        public T? Value { get; }
+        public string? Error { get; }
 
+        private Result(bool success, T? value, string? error)
+        {
+            Success = success;
+            Value = value;
+            Error = error;
+        }
+
+        public static Result<T> Ok(T value) => new(true, value, null);
+        public static Result<T> UnexpectedToken(SelectTokenizer.Token token) => new(false, default, $"Unexpected token '{token.Type}'");
+
+        public static Result<T> FromError<TOther>(Result<TOther> other)
+        {
+            if (other.Success) throw new InvalidOperationException();
+
+            return new Result<T>(false, default, other.Error);
+        }
+    }
 }

--- a/SelectParser/Parser.cs
+++ b/SelectParser/Parser.cs
@@ -112,6 +112,8 @@ public class Parser
             {
                 SelectToken.Equal => BinaryOperator.Equal,
                 SelectToken.NotEqual => BinaryOperator.NotEqual,
+                
+                _ => throw new InvalidOperationException("invalid operator"),
             };
             
             expr = Result<Expression>.Ok(new Expression.Binary(op, expr.Value!, rightExpr.Value!)); 
@@ -144,6 +146,8 @@ public class Parser
                 SelectToken.LesserOrEqual => BinaryOperator.LesserOrEqual,
                 SelectToken.Greater => BinaryOperator.Greater,
                 SelectToken.GreaterOrEqual => BinaryOperator.GreaterOrEqual,
+                
+                _ => throw new InvalidOperationException("invalid operator"),
             };
             
             expr = Result<Expression>.Ok(new Expression.Binary(op, expr.Value!, rightExpr.Value!));
@@ -355,6 +359,8 @@ public class Parser
             {
                 SelectToken.Add => BinaryOperator.Add,
                 SelectToken.Negate => BinaryOperator.Subtract,
+                
+                _ => throw new InvalidOperationException("invalid operator"),
             };
             
             expr = Result<Expression>.Ok(new Expression.Binary(op, expr.Value!, rightExpr.Value!)); 
@@ -385,6 +391,8 @@ public class Parser
                 SelectToken.Star => BinaryOperator.Multiply,
                 SelectToken.Divide => BinaryOperator.Divide,
                 SelectToken.Modulo => BinaryOperator.Modulo,
+                
+                _ => throw new InvalidOperationException("invalid operator"),
             };
             
             expr = Result<Expression>.Ok(new Expression.Binary(op, expr.Value!, rightExpr.Value!)); 
@@ -465,9 +473,9 @@ public class Parser
             if (!expr.Success) return expr;
             
             next = SelectTokenizer.Read(ref tokenizer);
-            if(next.Type != SelectToken.RightBracket) return Result<Expression>.UnexpectedToken(next);
+            if (next.Type != SelectToken.RightBracket) return Result<Expression>.UnexpectedToken(next);
             
-            return Result<Expression>.Ok(new Expression.FunctionExpression(new ScalarFunction(initial, new [] { expr.Value! })));
+            return Result<Expression>.Ok(new Expression.FunctionExpression(new ScalarFunction(initial, [expr.Value!])));
         }
         
         if (next.Type != SelectToken.Dot)

--- a/SelectParser/Queries/Column.cs
+++ b/SelectParser/Queries/Column.cs
@@ -1,6 +1,4 @@
-﻿using OneOf.Types;
-
-namespace SelectParser.Queries;
+﻿namespace SelectParser.Queries;
 
 public class Column
 {

--- a/SelectParser/Queries/Expression.cs
+++ b/SelectParser/Queries/Expression.cs
@@ -8,221 +8,101 @@ namespace SelectParser.Queries;
 [GenerateOneOf]
 public partial class Expression : OneOfBase<Expression.StringLiteral, Expression.NumberLiteral, Expression.BooleanLiteral, Expression.Identifier, Expression.Qualified, Expression.FunctionExpression, Expression.Unary, Expression.Binary, Expression.Between, Expression.IsNull, Expression.Presence, Expression.In, Expression.Like>
 {
-    public override string ToString() => Value.ToString();
+    public override string? ToString() => Value.ToString();
 
-    public class StringLiteral
+    public class StringLiteral(string value)
     {
-        public StringLiteral(string value) => Value = value;
-        public string Value { get; }
+        public string Value { get; } = value;
 
-        public bool Equals(StringLiteral other)
+        public bool Equals(StringLiteral? other)
         {
             if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
             return Value == other.Value;
         }
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is StringLiteral other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
 
-        public override bool Equals(object obj)
-        {
-            return ReferenceEquals(this, obj) || obj is StringLiteral other && Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (base.GetHashCode() * 397) ^ (Value?.GetHashCode() ?? 0);
-            }
-        }
-
-        public override string ToString()
-        {
-            // TODO handle escaping
-            return $"'{Value}'";
-        }
+        // TODO handle escaping
+        public override string ToString() => $"'{Value}'";
     }
-    public class NumberLiteral
+    public class NumberLiteral(decimal value)
     {
-        public NumberLiteral(decimal value) => Value = value;
-        public decimal Value { get; }
+        public decimal Value { get; } = value;
 
-        public bool Equals(NumberLiteral other)
+        public bool Equals(NumberLiteral? other)
         {
             if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
             return Value == other.Value;
         }
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is NumberLiteral other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
 
-        public override bool Equals(object obj)
-        {
-            return ReferenceEquals(this, obj) || obj is NumberLiteral other && Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            return Value.GetHashCode();
-        }
-
-        public override string ToString()
-        {
-            return $"{Value}";
-        }
+        public override string ToString() => $"{Value}";
     }
-    public class BooleanLiteral
+    public class BooleanLiteral(bool value)
     {
-        public BooleanLiteral(bool value) => Value = value;
-        public bool Value { get; }
+        public bool Value { get; } = value;
 
-        public bool Equals(BooleanLiteral other)
+        public bool Equals(BooleanLiteral? other)
         {
             if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
             return Value == other.Value;
         }
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is BooleanLiteral other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
 
-        public override bool Equals(object obj)
-        {
-            return ReferenceEquals(this, obj) || obj is BooleanLiteral other && Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            return Value.GetHashCode();
-        }
-
-        public override string ToString()
-        {
-            return Value ? "true" : "false";
-        }
+        public override string ToString() => Value ? "true" : "false";
     }
 
-    public class Identifier
+    public class Identifier(string name, bool caseSensitive)
     {
-        public Identifier(string name, bool caseSensitive)
-        {
-            Name = name;
-            CaseSensitive = caseSensitive;
-        }
+        public string Name { get; } = name;
+        public bool CaseSensitive { get; } = caseSensitive;
 
-        public string Name { get; }
-        public bool CaseSensitive { get; }
+        protected bool Equals(Identifier other) => Name == other.Name && CaseSensitive == other.CaseSensitive;
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Identifier other && Equals(other);
+        public override int GetHashCode() => unchecked((Name.GetHashCode() * 397) ^ CaseSensitive.GetHashCode());
 
-        protected bool Equals(Identifier other)
-        {
-            return Name == other.Name && CaseSensitive == other.CaseSensitive;
-        }
+        public static bool operator ==(Identifier left, Identifier right) => Equals(left, right);
+        public static bool operator !=(Identifier left, Identifier right) => !Equals(left, right);
 
-        public override bool Equals(object obj)
-        {
-            return ReferenceEquals(this, obj) || obj is Identifier other && Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ (Name?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ CaseSensitive.GetHashCode();
-                return hashCode;
-            }
-        }
-
-        public static bool operator ==(Identifier left, Identifier right)
-        {
-            return Equals(left, right);
-        }
-
-        public static bool operator !=(Identifier left, Identifier right)
-        {
-            return !Equals(left, right);
-        }
-
-        public override string ToString()
-        {
-            // TODO handle quoting
-            return Name;
-        }
+        // TODO handle quoting
+        public override string ToString() => Name;
     }
-    public class Qualified
+    public class Qualified(Identifier qualification, Expression expression)
     {
-        public Qualified(Identifier qualification, Expression expression)
-        {
-            Qualification = qualification;
-            Expression = expression;
-        }
+        public Identifier Qualification { get; } = qualification;
+        public Expression Expression { get; } = expression;
 
-        public Identifier Qualification { get; }
-        public Expression Expression { get; }
+        protected bool Equals(Qualified other) => Equals(Qualification, other.Qualification) && Equals(Expression, other.Expression);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Qualified other && Equals(other);
+        public override int GetHashCode() => unchecked((Qualification.GetHashCode() * 397) ^ Expression.GetHashCode());
 
-        protected bool Equals(Qualified other)
-        {
-            return Equals(Qualification, other.Qualification) && Equals(Expression, other.Expression);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return ReferenceEquals(this, obj) || obj is Qualified other && Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return ((Qualification?.GetHashCode() ?? 0) * 397) ^ (Expression?.GetHashCode() ?? 0);
-            }
-        }
-
-        public override string ToString()
-        {
-            return $"{Qualification}.{Expression}";
-        }
+        public override string ToString() => $"{Qualification}.{Expression}";
     }
 
-    public class FunctionExpression
+    public class FunctionExpression(Function function)
     {
-        public Function Function { get; }
+        public Function Function { get; } = function;
 
-        public FunctionExpression(Function function)
-        {
-            Function = function;
-        }
+        protected bool Equals(FunctionExpression other) => Function.Equals(other.Function);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is FunctionExpression other && Equals(other);
+        public override int GetHashCode() => Function.GetHashCode();
 
-        protected bool Equals(FunctionExpression other) => base.Equals(other) && Function.Equals(other.Function);
-        public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is FunctionExpression other && Equals(other);
-        public override int GetHashCode() { unchecked { return (base.GetHashCode() * 397) ^ Function.GetHashCode(); } }
-
-        public override string ToString() => Function.ToString();
+        public override string? ToString() => Function.ToString();
     }
 
-    public class Unary
+    public class Unary(UnaryOperator @operator, Expression expression)
     {
-        public Unary(UnaryOperator @operator, Expression expression)
-        {
-            Operator = @operator;
-            Expression = expression;
-        }
+        public UnaryOperator Operator { get; } = @operator;
+        public Expression Expression { get; } = expression;
 
-        public UnaryOperator Operator { get; }
-        public Expression Expression { get; }
-
-        protected bool Equals(Unary other)
-        {
-            return Operator == other.Operator && Equals(Expression, other.Expression);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return ReferenceEquals(this, obj) || obj is Unary other && Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return ((int)Operator * 397) ^ (Expression?.GetHashCode() ?? 0);
-            }
-        }
+        protected bool Equals(Unary other) => Operator == other.Operator && Equals(Expression, other.Expression);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Unary other && Equals(other);
+        public override int GetHashCode() => unchecked(((int)Operator * 397) ^ Expression.GetHashCode());
 
         public override string ToString()
         {
@@ -238,36 +118,15 @@ public partial class Expression : OneOfBase<Expression.StringLiteral, Expression
             return $"({op}{Expression})";
         }
     }
-    public class Binary
+    public class Binary(BinaryOperator @operator, Expression left, Expression right)
     {
-        public Binary(BinaryOperator @operator, Expression left, Expression right)
-        {
-            Operator = @operator;
-            Left = left;
-            Right = right;
-        }
+        public BinaryOperator Operator { get; } = @operator;
+        public Expression Left { get; } = left;
+        public Expression Right { get; } = right;
 
-        public BinaryOperator Operator { get; }
-        public Expression Left { get; }
-        public Expression Right { get; }
-
-        protected bool Equals(Binary other)
-        {
-            return Operator == other.Operator && Equals(Left, other.Left) && Equals(Right, other.Right);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return ReferenceEquals(this, obj) || obj is Binary other && Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return ((((int)Operator * 397) ^ (Left?.GetHashCode() ?? 0)) * 397) ^ (Right?.GetHashCode() ?? 0);
-            }
-        }
+        protected bool Equals(Binary other) => Operator == other.Operator && Equals(Left, other.Left) && Equals(Right, other.Right);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Binary other && Equals(other);
+        public override int GetHashCode() => unchecked(((((int)Operator * 397) ^ Left.GetHashCode()) * 397) ^ Right.GetHashCode());
 
         public override string ToString()
         {
@@ -298,123 +157,52 @@ public partial class Expression : OneOfBase<Expression.StringLiteral, Expression
             return $"({Left} {op} {Right})";
         }
     }
-    public class Between
+    public class Between(bool negate, Expression expression, Expression lower, Expression upper)
     {
-        public Between(bool negate, Expression expression, Expression lower, Expression upper)
-        {
-            Negate = negate;
-            Expression = expression;
-            Lower = lower;
-            Upper = upper;
-        }
+        public bool Negate { get; } = negate;
+        public Expression Expression { get; } = expression;
+        public Expression Lower { get; } = lower;
+        public Expression Upper { get; } = upper;
 
-        public bool Negate { get; }
-        public Expression Expression { get; }
-        public Expression Lower { get; }
-        public Expression Upper { get; }
-
-        protected bool Equals(Between other)
-        {
-            return Negate == other.Negate && Equals(Expression, other.Expression) && Equals(Lower, other.Lower) && Equals(Upper, other.Upper);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return ReferenceEquals(this, obj) || obj is Between other && Equals(other);
-        }
-
+        protected bool Equals(Between other) => Negate == other.Negate && Equals(Expression, other.Expression) && Equals(Lower, other.Lower) && Equals(Upper, other.Upper);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Between other && Equals(other);
         public override int GetHashCode()
         {
             unchecked
             {
                 var hashCode = Negate.GetHashCode();
-                hashCode = (hashCode * 397) ^ (Expression != null ? Expression.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (Lower != null ? Lower.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (Upper != null ? Upper.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ Expression.GetHashCode();
+                hashCode = (hashCode * 397) ^ Lower.GetHashCode();
+                hashCode = (hashCode * 397) ^ Upper.GetHashCode();
                 return hashCode;
             }
         }
 
-        public override string ToString()
-        {
-            // TODO bracketing?
-            return $"{Expression}{(Negate ? " NOT" : "")} BETWEEN {Lower} AND {Upper}";
-        }
+        // TODO bracketing?
+        public override string ToString() => $"{Expression}{(Negate ? " NOT" : "")} BETWEEN {Lower} AND {Upper}";
     }
 
-    public class IsNull
+    public class IsNull(Expression expression, bool negate)
     {
-        public IsNull(Expression expression, bool negate)
-        {
-            Expression = expression;
-            Negate = negate;
-        }
+        public Expression Expression { get; } = expression;
+        public bool Negate { get; } = negate;
 
-        public Expression Expression { get; }
-        public bool Negate { get; }
+        protected bool Equals(IsNull other) => Equals(Expression, other.Expression) && Negate == other.Negate;
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is IsNull other && Equals(other);
+        public override int GetHashCode() => unchecked((Expression.GetHashCode() * 397) ^ Negate.GetHashCode());
 
-        protected bool Equals(IsNull other)
-        {
-            return base.Equals(other) && Equals(Expression, other.Expression) && Negate == other.Negate;
-        }
-
-        public override bool Equals(object obj)
-        {
-            return ReferenceEquals(this, obj) || obj is IsNull other && Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ (Expression?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ Negate.GetHashCode();
-                return hashCode;
-            }
-        }
-
-        public override string ToString()
-        {
-            return $"{Expression} IS {(Negate ? "NOT " : "")}NULL";
-        }
+        public override string ToString() => $"{Expression} IS {(Negate ? "NOT " : "")}NULL";
     }
-    public class Presence
+    public class Presence(Expression expression, bool negate)
     {
-        public Presence(Expression expression, bool negate)
-        {
-            Expression = expression;
-            Negate = negate;
-        }
+        public Expression Expression { get; } = expression;
+        public bool Negate { get; } = negate;
 
-        public Expression Expression { get; }
-        public bool Negate { get; }
+        protected bool Equals(Presence other) => Equals(Expression, other.Expression) && Negate == other.Negate;
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Presence other && Equals(other);
+        public override int GetHashCode() => unchecked((Expression.GetHashCode() * 397) ^ Negate.GetHashCode());
 
-        protected bool Equals(Presence other)
-        {
-            return base.Equals(other) && Equals(Expression, other.Expression) && Negate == other.Negate;
-        }
-
-        public override bool Equals(object obj)
-        {
-            return ReferenceEquals(this, obj) || obj is Presence other && Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ (Expression?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ Negate.GetHashCode();
-                return hashCode;
-            }
-        }
-
-        public override string ToString()
-        {
-            return $"{Expression} IS {(Negate ? "" : "NOT ")}MISSING";
-        }
+        public override string ToString() => $"{Expression} IS {(Negate ? "" : "NOT ")}MISSING";
     }
     public class In
     {
@@ -436,69 +224,32 @@ public partial class Expression : OneOfBase<Expression.StringLiteral, Expression
         /// </summary>
         public IReadOnlyCollection<string>? StringMatches { get; } 
         
-        protected bool Equals(In other)
-        {
-            return base.Equals(other) && Equals(Expression, other.Expression) && Matches.SequenceEqual(other.Matches);
-        }
+        protected bool Equals(In other) => Equals(Expression, other.Expression) && Matches.SequenceEqual(other.Matches);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is In other && Equals(other);
+        public override int GetHashCode() => unchecked((Expression.GetHashCode() * 397) ^ Matches.GetHashCode());
 
-        public override bool Equals(object obj)
-        {
-            return ReferenceEquals(this, obj) || obj is In other && Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = base.GetHashCode();
-                hashCode = (hashCode * 397) ^ (Expression?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ (Matches?.GetHashCode() ?? 0);
-                return hashCode;
-            }
-        }
-
-        public override string ToString()
-        {
-            return $"{Expression} IN ({string.Join(", ", Matches)})";
-        }
+        public override string ToString() => $"{Expression} IN ({string.Join(", ", Matches)})";
     }
-    public class Like
+    public class Like(Expression expression, Expression pattern, Option<Expression> escape)
     {
-        public Like(Expression expression, Expression pattern, Option<Expression> escape)
-        {
-            Expression = expression;
-            Pattern = pattern;
-            Escape = escape;
-        }
+        public Expression Expression { get; } = expression;
+        public Expression Pattern { get; } = pattern;
+        public Option<Expression> Escape { get; } = escape;
 
-        public Expression Expression { get; }
-        public Expression Pattern { get; }
-        public Option<Expression> Escape { get; }
-
-        protected bool Equals(Like other)
-        {
-            return Equals(Expression, other.Expression) && Equals(Pattern, other.Pattern) && Equals(Escape, other.Escape);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return ReferenceEquals(this, obj) || obj is Like other && Equals(other);
-        }
+        protected bool Equals(Like other) => Equals(Expression, other.Expression) && Equals(Pattern, other.Pattern) && Equals(Escape, other.Escape);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Like other && Equals(other);
 
         public override int GetHashCode()
         {
             unchecked
             {
-                var hashCode = Expression?.GetHashCode() ?? 0;
-                hashCode = (hashCode * 397) ^ (Pattern?.GetHashCode() ?? 0);
+                var hashCode = Expression.GetHashCode();
+                hashCode = (hashCode * 397) ^ Pattern.GetHashCode();
                 hashCode = (hashCode * 397) ^ Escape.GetHashCode();
                 return hashCode;
             }
         }
 
-        public override string ToString()
-        {
-            return Escape.IsNone ? $"{Expression} LIKE {Pattern}" : $"{Expression} LIKE {Pattern} ESCAPE {Escape.AsT0}";
-        }
+        public override string ToString() => Escape.IsNone ? $"{Expression} LIKE {Pattern}" : $"{Expression} LIKE {Pattern} ESCAPE {Escape.AsT0}";
     }
 }

--- a/SelectParser/Queries/Expression.cs
+++ b/SelectParser/Queries/Expression.cs
@@ -491,7 +491,7 @@ public partial class Expression : OneOfBase<Expression.StringLiteral, Expression
             {
                 var hashCode = Expression?.GetHashCode() ?? 0;
                 hashCode = (hashCode * 397) ^ (Pattern?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ (Escape?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ Escape.GetHashCode();
                 return hashCode;
             }
         }

--- a/SelectParser/Queries/FromClause.cs
+++ b/SelectParser/Queries/FromClause.cs
@@ -1,6 +1,4 @@
-﻿using OneOf.Types;
-
-namespace SelectParser.Queries;
+﻿namespace SelectParser.Queries;
 
 public class FromClause
 {

--- a/SelectParser/Queries/Function.cs
+++ b/SelectParser/Queries/Function.cs
@@ -1,37 +1,39 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
-using OneOf;
 
 namespace SelectParser.Queries;
 
-[GenerateOneOf]
-public partial class Function : OneOfBase<AggregateFunction, ScalarFunction>
+public abstract class Function : IEquatable<Function>
 {
-    public override string? ToString() => Value.ToString();
+    public abstract bool Equals(Function? other);
 }
 
-[GenerateOneOf]
-public partial class AggregateFunction : OneOfBase<AggregateFunction.Average, AggregateFunction.Count,
-    AggregateFunction.Max, AggregateFunction.Min, AggregateFunction.Sum>
+public abstract class AggregateFunction : Function, IEquatable<AggregateFunction>
 {
-    public override string? ToString() => Value.ToString();
+    public override bool Equals(Function? other) => Equals(other as AggregateFunction);
+    public abstract bool Equals(AggregateFunction? other);
+    public abstract override bool Equals(object? obj);
+    public abstract override int GetHashCode();
 
-    public class Average(Expression expression)
+    public class Average(Expression expression) : AggregateFunction, IEquatable<Average>
     {
         public Expression Expression { get; } = expression;
 
-        protected bool Equals(Average other) => Expression.Equals(other.Expression);
+        public override bool Equals(AggregateFunction? other) => Equals(other as Average);
+        public bool Equals(Average? other) => other is not null && Expression.Equals(other.Expression);
         public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Average other && Equals(other);
         public override int GetHashCode() => Expression.GetHashCode();
 
         public override string ToString() => $"AVG({Expression})";
     }
 
-    public class Count(Option<Expression> expression)
+    public class Count(Option<Expression> expression) : AggregateFunction, IEquatable<Count>
     {
         public Option<Expression> Expression { get; } = expression;
 
-        protected bool Equals(Count other) => Expression.Equals(other.Expression);
+        public override bool Equals(AggregateFunction? other) => Equals(other as Count);
+        public bool Equals(Count? other) => other is not null && Expression.Equals(other.Expression);
         public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Count other && Equals(other);
 
         public override int GetHashCode() => Expression.GetHashCode();
@@ -39,33 +41,36 @@ public partial class AggregateFunction : OneOfBase<AggregateFunction.Average, Ag
         public override string ToString() => $"COUNT({(Expression.IsSome ? Expression : "*")})";
     }
 
-    public class Max(Expression expression)
+    public class Max(Expression expression) : AggregateFunction, IEquatable<Max>
     {
         public Expression Expression { get; } = expression;
 
-        protected bool Equals(Max other) => Expression.Equals(other.Expression);
+        public override bool Equals(AggregateFunction? other) => Equals(other as Max);
+        public bool Equals(Max? other) => other is not null && Expression.Equals(other.Expression);
         public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Max other && Equals(other);
         public override int GetHashCode() => Expression.GetHashCode();
 
         public override string ToString() => $"MAX({Expression})";
     }
 
-    public class Min(Expression expression)
+    public class Min(Expression expression) : AggregateFunction, IEquatable<Min>
     {
         public Expression Expression { get; } = expression;
 
-        protected bool Equals(Min other) => Expression.Equals(other.Expression);
+        public override bool Equals(AggregateFunction? other) => Equals(other as Min);
+        public bool Equals(Min? other) => other is not null && Expression.Equals(other.Expression);
         public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Min other && Equals(other);
         public override int GetHashCode() => Expression.GetHashCode();
 
         public override string ToString() => $"MIN({Expression})";
     }
 
-    public class Sum(Expression expression)
+    public class Sum(Expression expression) : AggregateFunction, IEquatable<Sum>
     {
         public Expression Expression { get; } = expression;
 
-        protected bool Equals(Sum other) => Expression.Equals(other.Expression);
+        public override bool Equals(AggregateFunction? other) => Equals(other as Sum);
+        public bool Equals(Sum? other) => other is not null && Expression.Equals(other.Expression);
         public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Sum other && Equals(other);
         public override int GetHashCode() => Expression.GetHashCode();
 
@@ -73,12 +78,13 @@ public partial class AggregateFunction : OneOfBase<AggregateFunction.Average, Ag
     }
 }
 
-public class ScalarFunction(Expression.Identifier identifier, IReadOnlyList<Expression> arguments)
+public class ScalarFunction(Expression.Identifier identifier, IReadOnlyList<Expression> arguments) : Function, IEquatable<ScalarFunction>
 {
     public Expression.Identifier Identifier { get; } = identifier;
     public IReadOnlyList<Expression> Arguments { get; } = arguments;
 
-    protected bool Equals(ScalarFunction other) => Identifier.Equals(other.Identifier) && Arguments.SequenceEqual(other.Arguments);
+    public override bool Equals(Function? other) => Equals(other as ScalarFunction);
+    public bool Equals(ScalarFunction? other) => other is not null && Identifier.Equals(other.Identifier) && Arguments.SequenceEqual(other.Arguments);
     public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is ScalarFunction other && Equals(other);
 
     public override int GetHashCode()

--- a/SelectParser/Queries/Function.cs
+++ b/SelectParser/Queries/Function.cs
@@ -7,155 +7,79 @@ namespace SelectParser.Queries;
 [GenerateOneOf]
 public partial class Function : OneOfBase<AggregateFunction, ScalarFunction>
 {
-    public override string ToString() => Value.ToString();
+    public override string? ToString() => Value.ToString();
 }
 
 [GenerateOneOf]
 public partial class AggregateFunction : OneOfBase<AggregateFunction.Average, AggregateFunction.Count,
     AggregateFunction.Max, AggregateFunction.Min, AggregateFunction.Sum>
 {
-    public override string ToString() => Value.ToString();
+    public override string? ToString() => Value.ToString();
 
-    public class Average
+    public class Average(Expression expression)
     {
-        public Average(Expression expression)
-        {
-            Expression = expression;
-        }
+        public Expression Expression { get; } = expression;
 
-        public Expression Expression { get; }
-
-        protected bool Equals(Average other) => base.Equals(other) && Expression.Equals(other.Expression);
-
-        public override bool Equals(object obj) =>
-            ReferenceEquals(this, obj) || obj is Average other && Equals(other);
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (base.GetHashCode() * 397) ^ Expression.GetHashCode();
-            }
-        }
+        protected bool Equals(Average other) => Expression.Equals(other.Expression);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Average other && Equals(other);
+        public override int GetHashCode() => Expression.GetHashCode();
 
         public override string ToString() => $"AVG({Expression})";
     }
 
-    public class Count
+    public class Count(Option<Expression> expression)
     {
-        public Count(Option<Expression> expression)
-        {
-            Expression = expression;
-        }
+        public Option<Expression> Expression { get; } = expression;
 
-        public Option<Expression> Expression { get; }
+        protected bool Equals(Count other) => Expression.Equals(other.Expression);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Count other && Equals(other);
 
-        protected bool Equals(Count other) => base.Equals(other) && Expression.Equals(other.Expression);
-
-        public override bool Equals(object obj) =>
-            ReferenceEquals(this, obj) || obj is Count other && Equals(other);
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (base.GetHashCode() * 397) ^ Expression.GetHashCode();
-            }
-        }
+        public override int GetHashCode() => Expression.GetHashCode();
 
         public override string ToString() => $"COUNT({(Expression.IsSome ? Expression : "*")})";
     }
 
-    public class Max
+    public class Max(Expression expression)
     {
-        public Max(Expression expression)
-        {
-            Expression = expression;
-        }
+        public Expression Expression { get; } = expression;
 
-        public Expression Expression { get; }
-
-        protected bool Equals(Max other) => base.Equals(other) && Expression.Equals(other.Expression);
-        public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Max other && Equals(other);
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (base.GetHashCode() * 397) ^ Expression.GetHashCode();
-            }
-        }
+        protected bool Equals(Max other) => Expression.Equals(other.Expression);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Max other && Equals(other);
+        public override int GetHashCode() => Expression.GetHashCode();
 
         public override string ToString() => $"MAX({Expression})";
     }
 
-    public class Min
+    public class Min(Expression expression)
     {
-        public Min(Expression expression)
-        {
-            Expression = expression;
-        }
+        public Expression Expression { get; } = expression;
 
-        public Expression Expression { get; }
-
-        protected bool Equals(Min other) => base.Equals(other) && Expression.Equals(other.Expression);
-        public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Min other && Equals(other);
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (base.GetHashCode() * 397) ^ Expression.GetHashCode();
-            }
-        }
+        protected bool Equals(Min other) => Expression.Equals(other.Expression);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Min other && Equals(other);
+        public override int GetHashCode() => Expression.GetHashCode();
 
         public override string ToString() => $"MIN({Expression})";
     }
 
-    public class Sum
+    public class Sum(Expression expression)
     {
-        public Sum(Expression expression)
-        {
-            Expression = expression;
-        }
+        public Expression Expression { get; } = expression;
 
-        public Expression Expression { get; }
-
-        protected bool Equals(Sum other) => base.Equals(other) && Expression.Equals(other.Expression);
-        public override bool Equals(object obj) => ReferenceEquals(this, obj) || obj is Sum other && Equals(other);
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (base.GetHashCode() * 397) ^ Expression.GetHashCode();
-            }
-        }
+        protected bool Equals(Sum other) => Expression.Equals(other.Expression);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is Sum other && Equals(other);
+        public override int GetHashCode() => Expression.GetHashCode();
 
         public override string ToString() => $"SUM({Expression})";
     }
 }
 
-public class ScalarFunction
+public class ScalarFunction(Expression.Identifier identifier, IReadOnlyList<Expression> arguments)
 {
-    public ScalarFunction(Expression.Identifier identifier, IReadOnlyList<Expression> arguments)
-    {
-        Identifier = identifier;
-        Arguments = arguments;
-    }
+    public Expression.Identifier Identifier { get; } = identifier;
+    public IReadOnlyList<Expression> Arguments { get; } = arguments;
 
-    public Expression.Identifier Identifier { get; }
-    public IReadOnlyList<Expression> Arguments { get; }
-
-    protected bool Equals(ScalarFunction other)
-    {
-        return Identifier.Equals(other.Identifier) && Arguments.SequenceEqual(other.Arguments);
-    }
-
-    public override bool Equals(object? obj)
-    {
-        return ReferenceEquals(this, obj) || obj is ScalarFunction other && Equals(other);
-    }
+    protected bool Equals(ScalarFunction other) => Identifier.Equals(other.Identifier) && Arguments.SequenceEqual(other.Arguments);
+    public override bool Equals(object? obj) => ReferenceEquals(this, obj) || obj is ScalarFunction other && Equals(other);
 
     public override int GetHashCode()
     {
@@ -172,8 +96,5 @@ public class ScalarFunction
         }
     }
 
-    public override string ToString()
-    {
-        return $"{Identifier.Name}({string.Join(", ", Arguments)})";
-    }
+    public override string ToString() => $"{Identifier.Name}({string.Join(", ", Arguments)})";
 }

--- a/SelectParser/Queries/Query.cs
+++ b/SelectParser/Queries/Query.cs
@@ -2,44 +2,40 @@
 
 namespace SelectParser.Queries;
 
-public class Query
+public class Query(
+    SelectClause select,
+    FromClause from,
+    Option<WhereClause> where,
+    Option<OrderClause> order,
+    Option<LimitClause> limit)
 {
-    public Query(SelectClause select, FromClause from, Option<WhereClause> where, Option<OrderClause> order, Option<LimitClause> limit)
-    {
-        Select = select;
-        From = from;
-        Where = where;
-        Order = order;
-        Limit = limit;
-    }
-
-    public SelectClause Select { get; }
-    public FromClause From { get; }
-    public Option<WhereClause> Where { get; }
-    public Option<OrderClause> Order { get; }
-    public Option<LimitClause> Limit { get; }
+    public SelectClause Select { get; } = select;
+    public FromClause From { get; } = from;
+    public Option<WhereClause> Where { get; } = where;
+    public Option<OrderClause> Order { get; } = order;
+    public Option<LimitClause> Limit { get; } = limit;
 
     public override string ToString()
     {
         var sb = new StringBuilder();
 
         sb.Append(Select);
-        sb.Append(" ");
+        sb.Append(' ');
         sb.Append(From);
 
         if (Where.IsSome)
         {
-            sb.Append(" ");
+            sb.Append(' ');
             sb.Append(Where.AsT0);
         }
         if (Order.IsSome)
         {
-            sb.Append(" ");
+            sb.Append(' ');
             sb.Append(Order.AsT0);
         }
         if (Limit.IsSome)
         {
-            sb.Append(" ");
+            sb.Append(' ');
             sb.Append(Limit.AsT0);
         }
 

--- a/SelectParser/Queries/SelectClause.cs
+++ b/SelectParser/Queries/SelectClause.cs
@@ -6,28 +6,17 @@ namespace SelectParser.Queries;
 [GenerateOneOf]
 public partial class SelectClause : OneOfBase<SelectClause.Star, SelectClause.List>
 {
-    public override string ToString() => Value.ToString();
+    public override string? ToString() => Value.ToString();
 
     public class Star
     {
-        public override string ToString()
-        {
-            return "SELECT *";
-        }
+        public override string ToString() => "SELECT *";
     }
 
-    public class List
+    public class List(IReadOnlyList<Column> columns)
     {
-        public List(IReadOnlyList<Column> columns)
-        {
-            Columns = columns;
-        }
+        public IReadOnlyList<Column> Columns { get; } = columns;
 
-        public IReadOnlyList<Column> Columns { get; }
-
-        public override string ToString()
-        {
-            return $"SELECT {string.Join(", ", Columns)}";
-        }
+        public override string ToString() => $"SELECT {string.Join(", ", Columns)}";
     }
 }

--- a/SelectParser/Queries/SelectClause.cs
+++ b/SelectParser/Queries/SelectClause.cs
@@ -1,22 +1,40 @@
-﻿using System.Collections.Generic;
-using OneOf;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SelectParser.Queries;
 
-[GenerateOneOf]
-public partial class SelectClause : OneOfBase<SelectClause.Star, SelectClause.List>
+public abstract class SelectClause : IEquatable<SelectClause>
 {
-    public override string? ToString() => Value.ToString();
+    public abstract bool Equals(SelectClause? other);
+    public abstract override bool Equals(object? obj);
+    public abstract override int GetHashCode();
 
-    public class Star
+    public class Star : SelectClause, IEquatable<Star>
     {
+        public override bool Equals(SelectClause? other) => Equals(other as Star);
+        public bool Equals(Star? other) => other is not null;
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || Equals(obj as Star);
+        public override int GetHashCode() => 11;
+
+        public static bool operator ==(Star? left, Star? right) => Equals(left, right);
+        public static bool operator !=(Star? left, Star? right) => !Equals(left, right);
+        
         public override string ToString() => "SELECT *";
     }
 
-    public class List(IReadOnlyList<Column> columns)
+    public class List(IReadOnlyList<Column> columns) : SelectClause, IEquatable<List>
     {
         public IReadOnlyList<Column> Columns { get; } = columns;
 
+        public override bool Equals(SelectClause? other) => Equals(other as List);
+        public bool Equals(List? other) => other is not null && Columns.SequenceEqual(other.Columns);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj) || Equals(obj as List);
+        public override int GetHashCode() => 11;
+
+        public static bool operator ==(List? left, List? right) => Equals(left, right);
+        public static bool operator !=(List? left, List? right) => !Equals(left, right);
+        
         public override string ToString() => $"SELECT {string.Join(", ", Columns)}";
     }
 }

--- a/SelectParser/SelectParser.csproj
+++ b/SelectParser/SelectParser.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
 
@@ -22,7 +22,10 @@
     <PackageReference Include="OneOf" Version="3.0.216"/>
     <PackageReference Include="OneOf.Extended" Version="3.0.216"/>
     <PackageReference Include="OneOf.SourceGenerator" Version="3.0.216"/>
-    <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SelectParser/SelectParser.csproj
+++ b/SelectParser/SelectParser.csproj
@@ -19,9 +19,6 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" PrivateAssets="All"/>
-    <PackageReference Include="OneOf" Version="3.0.216"/>
-    <PackageReference Include="OneOf.Extended" Version="3.0.216"/>
-    <PackageReference Include="OneOf.SourceGenerator" Version="3.0.216"/>
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/SelectParser/SelectParser.csproj
+++ b/SelectParser/SelectParser.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="OneOf" Version="3.0.216"/>
     <PackageReference Include="OneOf.Extended" Version="3.0.216"/>
     <PackageReference Include="OneOf.SourceGenerator" Version="3.0.216"/>
-    <PackageReference Include="Superpower" Version="2.3.0"/>
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SelectParser/SelectToken.cs
+++ b/SelectParser/SelectToken.cs
@@ -2,12 +2,17 @@
 
 public enum SelectToken
 {
-    None,
-    Identifier,
+    Error = -2,
+    Eof = -1,
+    Unknown = 0,
+
+    Identifier = 1,
+
     // literals
     StringLiteral,
     NumberLiteral,
     BooleanLiteral,
+
     // keywords
     Select,
     As,
@@ -22,12 +27,14 @@ public enum SelectToken
     Is,
     Missing,
     Null,
+
     // functions
     Avg,
     Count,
     Max,
     Min,
     Sum,
+
     // operators
     Dot,
     Comma,
@@ -51,11 +58,10 @@ public enum SelectToken
     Add,
     Divide,
     Modulo,
+    Concat,
 
     Between,
     In,
     Like,
     Escape,
-    
-    Concat,
 }

--- a/SelectParser/SelectTokenizer.cs
+++ b/SelectParser/SelectTokenizer.cs
@@ -1,182 +1,382 @@
 ﻿using System;
-using System.Collections.Generic;
-using Superpower;
-using Superpower.Model;
-using Superpower.Parsers;
+using System.Runtime.CompilerServices;
 
 namespace SelectParser;
 
-public class SelectTokenizer : Tokenizer<SelectToken>
+public ref struct SelectTokenizer(ReadOnlySpan<char> input, int offset = 0)
 {
-    private static readonly IReadOnlyDictionary<string, SelectToken> Keywords = new Dictionary<string, SelectToken>(StringComparer.InvariantCultureIgnoreCase)
+    private static Token Eof => new(SelectToken.Eof, ReadOnlySpan<char>.Empty);
+
+    private readonly ReadOnlySpan<char> _input = input;
+    private int _offset = offset;
+    
+    public static Token Read(ref SelectTokenizer lexer)
     {
-        { "SELECT", SelectToken.Select },
-        { "AS", SelectToken.As },
-        { "FROM", SelectToken.From },
-        { "WHERE", SelectToken.Where },
-        { "ORDER", SelectToken.Order },
-        { "BY", SelectToken.By },
-        { "LIMIT", SelectToken.Limit },
-        { "OFFSET", SelectToken.Offset },
-        { "ASC", SelectToken.Asc },
-        { "DESC", SelectToken.Desc },
-        { "IS", SelectToken.Is },
-        { "MISSING", SelectToken.Missing },
-        { "NULL", SelectToken.Null },
+        var result = SkipWhiteSpace(ref lexer);
+        if (result == Result.Eof) return Eof;
 
-        { "AVG", SelectToken.Avg },
-        { "COUNT", SelectToken.Count },
-        { "MAX", SelectToken.Max },
-        { "MIN", SelectToken.Min },
-        { "SUM", SelectToken.Sum },
+        var next = lexer._input[lexer._offset];
+        
+        // identifier
+        if (char.IsLetter(next) || next == '_')
+        {
+            var start = lexer._offset++;
 
-        { "TRUE", SelectToken.BooleanLiteral },
-        { "FALSE", SelectToken.BooleanLiteral },
+            while (true)
+            {
+                if (lexer._offset >= lexer._input.Length)
+                {
+                    // eof, so this must be the end of the identifier
+                    break;
+                }
 
-        { "NOT", SelectToken.Not },
-        { "AND", SelectToken.And },
-        { "OR", SelectToken.Or },
-        { "BETWEEN", SelectToken.Between },
-        { "IN", SelectToken.In },
-        { "LIKE", SelectToken.Like },
-        { "ESCAPE", SelectToken.Escape },
-    };
+                next = lexer._input[lexer._offset];
+                // check the next char is an identifier
+                if(!char.IsLetterOrDigit(next) && next != '_')
+                {
+                    // it wasn't, so we've reached the end of the identifier
+                    break;
+                }
 
-    private static readonly SelectToken[] SimpleOperator = new SelectToken[128];
+                // it was, so skip it
+                lexer._offset++;
+            }
+            
+            var end = lexer._offset;
 
-    private static readonly TextParser<string> QuotedIdentifier =
-        Character.EqualTo('"')
-            .IgnoreThen(Character.ExceptIn('"', '\r', '\n').Many())
-            .Then(s => Character.EqualTo('"').Value(new string(s)));
+            var text = lexer._input.Slice(start, end - start);
 
-    private static readonly TextParser<string> StringLiteral =
-        Character.EqualTo('\'')
-            .IgnoreThen(Span.EqualTo("''").Value('\'').Try().Or(Character.ExceptIn('\'', '\r', '\n')).Many())
-            .Then(s => Character.EqualTo('\'').Value(new string(s)));
+            if (IsIdentifier(text, "SELECT")) { return new Token(SelectToken.Select, text); }
+            if (IsIdentifier(text, "AS")) { return new Token(SelectToken.As, text); }
+            if (IsIdentifier(text, "FROM")) { return new Token(SelectToken.From, text); }
+            if (IsIdentifier(text, "WHERE")) { return new Token(SelectToken.Where, text); }
+            if (IsIdentifier(text, "ORDER")) { return new Token(SelectToken.Order, text); }
+            if (IsIdentifier(text, "BY")) { return new Token(SelectToken.By, text); }
+            if (IsIdentifier(text, "LIMIT")) { return new Token(SelectToken.Limit, text); }
+            if (IsIdentifier(text, "OFFSET")) { return new Token(SelectToken.Offset, text); }
+            if (IsIdentifier(text, "ASC")) { return new Token(SelectToken.Asc, text); }
+            if (IsIdentifier(text, "DESC")) { return new Token(SelectToken.Desc, text); }
+            if (IsIdentifier(text, "IS")) { return new Token(SelectToken.Is, text); }
+            if (IsIdentifier(text, "MISSING")) { return new Token(SelectToken.Missing, text); }
+            if (IsIdentifier(text, "NULL")) { return new Token(SelectToken.Null, text); }
+            if (IsIdentifier(text, "AVG")) { return new Token(SelectToken.Avg, text); }
+            if (IsIdentifier(text, "COUNT")) { return new Token(SelectToken.Count, text); }
+            if (IsIdentifier(text, "MAX")) { return new Token(SelectToken.Max, text); }
+            if (IsIdentifier(text, "MIN")) { return new Token(SelectToken.Min, text); }
+            if (IsIdentifier(text, "SUM")) { return new Token(SelectToken.Sum, text); }
+            if (IsIdentifier(text, "TRUE")) { return new Token(SelectToken.BooleanLiteral, text); }
+            if (IsIdentifier(text, "FALSE")) { return new Token(SelectToken.BooleanLiteral, text); }
+            if (IsIdentifier(text, "NOT")) { return new Token(SelectToken.Not, text); }
+            if (IsIdentifier(text, "AND")) { return new Token(SelectToken.And, text); }
+            if (IsIdentifier(text, "OR")) { return new Token(SelectToken.Or, text); }
+            if (IsIdentifier(text, "BETWEEN")) { return new Token(SelectToken.Between, text); }
+            if (IsIdentifier(text, "IN")) { return new Token(SelectToken.In, text); }
+            if (IsIdentifier(text, "LIKE")) { return new Token(SelectToken.Like, text); }
+            if (IsIdentifier(text, "ESCAPE")) { return new Token(SelectToken.Escape, text); }
+            
+            return new Token(SelectToken.Identifier, text);
 
-    private static readonly TextParser<TextSpan> NumberLiteral =
-        Numerics.Integer
-            .Then(n => Character.EqualTo('.').IgnoreThen(Numerics.Integer).OptionalOrDefault()
-                .Select(f => f == TextSpan.None ? n : new TextSpan(n.Source, n.Position, n.Length + f.Length + 1)));
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static bool IsIdentifier(ReadOnlySpan<char> text, string token) => text.Equals(token.AsSpan(), StringComparison.OrdinalIgnoreCase);
+        }
+        
+        if (next == '"')
+        {
+            var start = lexer._offset++;
 
-    private static readonly TextParser<SelectToken> And = Span.EqualTo("&&").Value(SelectToken.And);
-    private static readonly TextParser<SelectToken> LesserOrEqual = Span.EqualTo("<=").Value(SelectToken.LesserOrEqual);
-    private static readonly TextParser<SelectToken> GreaterOrEqual = Span.EqualTo(">=").Value(SelectToken.GreaterOrEqual);
-    private static readonly TextParser<SelectToken> Equal = Span.EqualTo("==").Value(SelectToken.Equal);
-    private static readonly TextParser<SelectToken> NotEqual = Span.EqualTo("!=").Or(Span.EqualTo("<>")).Value(SelectToken.NotEqual);
-    private static readonly TextParser<SelectToken> Concat = Span.EqualTo("||").Value(SelectToken.Concat);
+            while (true)
+            {
+                if (lexer._offset >= lexer._input.Length)
+                {
+                    // eof, this is an error
+                    return new Token(SelectToken.Error, "Unexpected EOF in QuotedIdentifier".AsSpan());
+                }
 
-    private static readonly TextParser<SelectToken> CompoundOperator =
-        And.Or(Concat.Or(GreaterOrEqual.Or(Equal.Or(LesserOrEqual.Try().Or(NotEqual)))));
+                next = lexer._input[lexer._offset];
+                if(next == '"')
+                {
+                    // reached the end of the quoted section
+                    break;
+                }
 
-    static SelectTokenizer()
+                lexer._offset++;
+            }
+            
+            // make sure we actually consume the end quote
+            var end = ++lexer._offset;
+
+            var text = lexer._input.Slice(start, end - start);
+
+            return new Token(SelectToken.Identifier, text);
+        }
+
+        if (next == '\'')
+        {
+            var start = lexer._offset++;
+
+            while (true)
+            {
+                if (lexer._offset >= lexer._input.Length)
+                {
+                    // eof, this is an error
+                    return new Token(SelectToken.Error, "Unexpected EOF in StringLiteral".AsSpan());
+                }
+
+                next = lexer._input[lexer._offset];
+                if(next == '\'')
+                {
+                    // check the next char isn't also a quote
+                    if (lexer._offset + 1 >= lexer._input.Length || lexer._input[lexer._offset + 1] != '\'')
+                    {
+                        // reached the end of the quoted section
+                        break;
+                    }
+
+                    // consume the escape
+                    lexer._offset++;
+                }
+
+                lexer._offset++;
+            }
+            
+            // make sure we actually consume the end quote
+            var end = ++lexer._offset;
+
+            var text = lexer._input.Slice(start, end - start);
+
+            return new Token(SelectToken.StringLiteral, text);
+        }
+
+        if (char.IsDigit(next))
+        {
+            var start = lexer._offset++;
+            
+            while (true)
+            {
+                if (lexer._offset >= lexer._input.Length)
+                {
+                    // eof is OK in a number
+                    break;
+                }
+
+                next = lexer._input[lexer._offset];
+                if (!char.IsDigit(next))
+                {
+                    // wasn't a digit so lets move on
+                    break;
+                }
+
+                lexer._offset++;
+            }
+
+            if (lexer._offset < lexer._input.Length && lexer._input[lexer._offset] == '.')
+            {
+                // we found a decimal, lets continue
+                lexer._offset++;
+                
+                if (lexer._offset >= lexer._input.Length)
+                {
+                    // can't end a number of a decimal point
+                    return new Token(SelectToken.Error, "Unexpected EOF in NumberLiteral".AsSpan());
+                }
+
+                    
+                while (true)
+                {
+                    if (lexer._offset >= lexer._input.Length)
+                    {
+                        break;
+                    }
+
+                    next = lexer._input[lexer._offset];
+                    if (!char.IsDigit(next))
+                    {
+                        break;
+                    }
+
+                    lexer._offset++;
+                }
+
+            }
+            
+            var end = lexer._offset;
+
+            var text = lexer._input.Slice(start, end - start);
+
+            return new Token(SelectToken.NumberLiteral, text);
+
+        }
+
+        if (next == '&')
+        {
+            lexer._offset++;
+            
+            if (lexer._offset >= lexer._input.Length)
+            {
+                return new Token(SelectToken.Error, "Unexpected EOF in AND operator".AsSpan());
+            }
+            
+            next = lexer._input[lexer._offset];
+
+            if (next != '&')
+            {
+                return new Token(SelectToken.Error, "Unrecognised char in AND operator".AsSpan());
+            }
+
+            lexer._offset++;
+
+            return new Token(SelectToken.And, lexer._input.Slice(lexer._offset - 2, 2));
+        }
+        if (next == '|')
+        {
+            lexer._offset++;
+            
+            if (lexer._offset >= lexer._input.Length)
+            {
+                return new Token(SelectToken.Error, "Unexpected EOF in Concat operator".AsSpan());
+            }
+            
+            next = lexer._input[lexer._offset];
+
+            if (next != '|')
+            {
+                return new Token(SelectToken.Error, "Unrecognised char in Concat operator".AsSpan());
+            }
+
+            lexer._offset++;
+
+            return new Token(SelectToken.Concat, lexer._input.Slice(lexer._offset - 2, 2));
+        }     
+        if (next == '<')
+        {
+            lexer._offset++;
+            
+            if (lexer._offset >= lexer._input.Length)
+            {
+                return new Token(SelectToken.Lesser, lexer._input.Slice(lexer._offset - 1, 1));
+            }
+            
+            next = lexer._input[lexer._offset];
+
+            if (next == '=')
+            {
+                lexer._offset++;
+
+                return new Token(SelectToken.LesserOrEqual, lexer._input.Slice(lexer._offset - 2, 2));
+            }
+            
+            if (next == '>')
+            {
+                lexer._offset++;
+
+                return new Token(SelectToken.NotEqual, lexer._input.Slice(lexer._offset - 2, 2));
+            }
+
+            return new Token(SelectToken.Lesser, lexer._input.Slice(lexer._offset - 1, 1));
+        }    
+        if (next == '>')
+        {
+            lexer._offset++;
+            
+            if (lexer._offset >= lexer._input.Length)
+            {
+                return new Token(SelectToken.Greater, lexer._input.Slice(lexer._offset - 1, 1));
+            }
+            
+            next = lexer._input[lexer._offset];
+
+            if (next != '=')
+            {
+                return new Token(SelectToken.Greater, lexer._input.Slice(lexer._offset - 1, 1));
+            }
+
+            lexer._offset++;
+
+            return new Token(SelectToken.GreaterOrEqual, lexer._input.Slice(lexer._offset - 2, 2));
+        }   
+        if (next == '=')
+        {
+            lexer._offset++;
+            
+            if (lexer._offset >= lexer._input.Length)
+            {
+                return new Token(SelectToken.Equal, lexer._input.Slice(lexer._offset - 1, 1));
+            }
+            
+            next = lexer._input[lexer._offset];
+
+            if (next != '=')
+            {
+                return new Token(SelectToken.Equal, lexer._input.Slice(lexer._offset - 1, 1));
+            }
+
+            lexer._offset++;
+
+            return new Token(SelectToken.Equal, lexer._input.Slice(lexer._offset - 2, 2));
+        }
+        if (next == '!')
+        {
+            lexer._offset++;
+            
+            if (lexer._offset >= lexer._input.Length)
+            {
+                return new Token(SelectToken.Not, lexer._input.Slice(lexer._offset - 1, 1));
+            }
+            
+            next = lexer._input[lexer._offset];
+
+            if (next != '=')
+            {
+                return new Token(SelectToken.Not, lexer._input.Slice(lexer._offset - 1, 1));
+            }
+
+            lexer._offset++;
+
+            return new Token(SelectToken.NotEqual, lexer._input.Slice(lexer._offset - 2, 2));
+        }
+        
+        if (next == '.') { return new Token(SelectToken.Dot, lexer._input.Slice(lexer._offset++, 1)); }
+        if (next == ',') { return new Token(SelectToken.Comma, lexer._input.Slice(lexer._offset++, 1)); }
+        if (next == '(') { return new Token(SelectToken.LeftBracket, lexer._input.Slice(lexer._offset++, 1)); }
+        if (next == ')') { return new Token(SelectToken.RightBracket, lexer._input.Slice(lexer._offset++, 1)); }
+        if (next == '*') { return new Token(SelectToken.Star, lexer._input.Slice(lexer._offset++, 1)); }
+        if (next == '-') { return new Token(SelectToken.Negate, lexer._input.Slice(lexer._offset++, 1)); }
+        if (next == '+') { return new Token(SelectToken.Add, lexer._input.Slice(lexer._offset++, 1)); }
+        if (next == '/') { return new Token(SelectToken.Divide, lexer._input.Slice(lexer._offset++, 1)); }
+        if (next == '%') { return new Token(SelectToken.Modulo, lexer._input.Slice(lexer._offset++, 1)); }
+        
+        return new Token(SelectToken.Error, "Unrecognised char".AsSpan());
+    }
+    
+    private static Result SkipWhiteSpace(ref SelectTokenizer lexer)
     {
-        SimpleOperator['.'] = SelectToken.Dot;
-        SimpleOperator[','] = SelectToken.Comma;
-        SimpleOperator['('] = SelectToken.LeftBracket;
-        SimpleOperator[')'] = SelectToken.RightBracket;
-        SimpleOperator['*'] = SelectToken.Star;
+        while (lexer._offset < lexer._input.Length)
+        {
+            if (!char.IsWhiteSpace(lexer._input[lexer._offset]))
+            {
+                return Result.Ok;
+            }
 
-        SimpleOperator['!'] = SelectToken.Not;
-        SimpleOperator['-'] = SelectToken.Negate;
+            lexer._offset++;
+        }
 
-        SimpleOperator['<'] = SelectToken.Lesser;
-        SimpleOperator['>'] = SelectToken.Greater;
-        SimpleOperator['='] = SelectToken.Equal;
-
-        SimpleOperator['+'] = SelectToken.Add;
-        SimpleOperator['/'] = SelectToken.Divide;
-        SimpleOperator['%'] = SelectToken.Modulo;
+        return Result.Eof;
     }
 
-    protected override IEnumerable<Result<SelectToken>> Tokenize(TextSpan input)
+    private enum Result
     {
-        var next = SkipWhiteSpace(input);
+        Ok,
+        Eof,
+    }
+    
+    public readonly ref struct Token(SelectToken type, ReadOnlySpan<char> span)
+    {
+        public readonly SelectToken Type = type;
+        public readonly ReadOnlySpan<char> Span = span;
 
-        while (next.HasValue)
+        public string ToStringValue()
         {
-            if (char.IsLetter(next.Value) || next.Value == '_')
-            {
-                var start = next.Location;
-                do
-                {
-                    next = next.Remainder.ConsumeChar();
-                } while (next.HasValue && (char.IsLetterOrDigit(next.Value) || next.Value == '_'));
-                var end = next.Location;
-
-                var text = start.Until(end).ToStringValue();
-                if (Keywords.TryGetValue(text, out var token))
-                {
-                    yield return Result.Value(token, start, end);
-                }
-                else
-                {
-                    yield return Result.Value(SelectToken.Identifier, start, end);
-                }
-            }
-            else if (next.Value == '"')
-            {
-                var result = QuotedIdentifier(next.Location);
-                if (!result.HasValue)
-                {
-                    yield return Result.CastEmpty<string, SelectToken>(result);
-                }
-                else
-                {
-                    next = result.Remainder.ConsumeChar();
-                }
-
-                yield return Result.Value(SelectToken.Identifier, result.Location, result.Remainder);
-            }
-            else if (next.Value == '\'')
-            {
-                var result = StringLiteral(next.Location);
-                if (!result.HasValue)
-                {
-                    yield return Result.CastEmpty<string, SelectToken>(result);
-                }
-                else
-                {
-                    yield return Result.Value(SelectToken.StringLiteral, result.Location, result.Remainder);
-                }
-
-                next = result.Remainder.ConsumeChar();
-            }
-            else if (char.IsDigit(next.Value))
-            {
-                var result = NumberLiteral(next.Location);
-                if (!result.HasValue)
-                {
-                    yield return Result.CastEmpty<TextSpan, SelectToken>(result);
-                }
-                else
-                {
-                    yield return Result.Value(SelectToken.NumberLiteral, result.Location, result.Remainder);
-                }
-
-                next = result.Remainder.ConsumeChar();
-            }
-            else
-            {
-                var compound = CompoundOperator(next.Location);
-                if (compound.HasValue)
-                {
-                    yield return Result.Value(compound.Value, compound.Location, compound.Remainder);
-                    next = compound.Remainder.ConsumeChar();
-                }
-                else if (next.Value < SimpleOperator.Length && SimpleOperator[next.Value] != SelectToken.None)
-                {
-                    yield return Result.Value(SimpleOperator[next.Value], next.Location, next.Remainder);
-                    next = next.Remainder.ConsumeChar();
-                }
-                else
-                {
-                    yield return Result.Empty<SelectToken>(next.Location, $"unrecognised `{next.Value}`");
-                    next = next.Remainder.ConsumeChar();
-                }
-            }
-
-            next = SkipWhiteSpace(next.Location);
+            return new string(Span.ToArray());
         }
     }
 }

--- a/SelectQuery.Benchmarks/ParsingBenchmarks.cs
+++ b/SelectQuery.Benchmarks/ParsingBenchmarks.cs
@@ -1,0 +1,38 @@
+﻿using BenchmarkDotNet.Attributes;
+using SelectParser;
+using SelectParser.Queries;
+
+namespace SelectQuery.Benchmarks;
+
+[ShortRunJob]
+[MemoryDiagnoser]
+public class ParsingBenchmarks
+{
+    [ParamsSource(nameof(ValuesForTestCases))]
+    public TestCase Query { get; set; }
+
+    public static IEnumerable<TestCase> ValuesForTestCases
+    {
+        get
+        {
+            yield return new TestCase("simple", "SELECT * FROM s3Object");
+            yield return new TestCase("projection", "SELECT s.a, s.b, s.c FROM s3Object s");
+            yield return new TestCase("filtered", "SELECT * FROM s3Object s WHERE s.a = 1 AND s.b = true AND s.c = 'def'");
+            yield return new TestCase("aggregated", "SELECT MAX(s.a), SUM(s.b), AVG(s.c) FROM s3Object s");
+            
+            yield return new TestCase("large projection", $"SELECT {string.Join(", ", Enumerable.Range(0, 1000).Select(x => $"s.c{x}"))} FROM s3Object s");
+            yield return new TestCase("large IN filter", $"SELECT * FROM s3Object s WHERE s.a IN ({string.Join(", ", Enumerable.Range(0, 1000).Select(x => $"'str{x}'"))})");
+        }
+    }
+    
+    [Benchmark]
+    public Query Parse() => Parser.Parse(Query.QueryString).Value;
+    
+    public class TestCase(string name, string queryString)
+    {
+        public string Name { get; } = name;
+        public string QueryString { get; } = queryString;
+
+        public override string ToString() => Name;
+    }
+}

--- a/SelectQuery.Benchmarks/Program.cs
+++ b/SelectQuery.Benchmarks/Program.cs
@@ -1,4 +1,5 @@
 ﻿using BenchmarkDotNet.Running;
 using SelectQuery.Benchmarks;
 
-var summary = BenchmarkRunner.Run<EvaluationBenchmarks>();
+// var summary = BenchmarkRunner.Run<EvaluationBenchmarks>();
+var summary = BenchmarkRunner.Run<ParsingBenchmarks>();

--- a/SelectQuery.Evaluation.Tests/EvaluatorTests.cs
+++ b/SelectQuery.Evaluation.Tests/EvaluatorTests.cs
@@ -168,7 +168,12 @@ public class EvaluatorTests
     private static Query ParseQuery(string query)
     {
         var result = Parser.Parse(query);
-        return result.Value;
+        if (!result.Success)
+        {
+            throw new Exception("Failed to parse query: " + result.Error);
+        }
+        
+        return result.Value!;
     }
 
     private static byte[] Evaluate(Query query, string[] data)

--- a/SelectQuery.Evaluation/ExpressionEvaluator.cs
+++ b/SelectQuery.Evaluation/ExpressionEvaluator.cs
@@ -151,7 +151,7 @@ public class ExpressionEvaluator
             return leftNum + rightNum;
         }
 
-        if (left.IsNone || left.Value is null) return right?.Value?.ToString();
+        if (left.IsNone || left.Value is null) return right.Value?.ToString();
         if (right.IsNone || right.Value is null) return null;
 
         return $"{left.Value}{right.Value}";

--- a/SelectQuery.Evaluation/FunctionEvaluator.cs
+++ b/SelectQuery.Evaluation/FunctionEvaluator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using OneOf.Types;
 using SelectParser;
 
 namespace SelectQuery.Evaluation;

--- a/SelectQuery.Evaluation/JsonLinesEvaluator.cs
+++ b/SelectQuery.Evaluation/JsonLinesEvaluator.cs
@@ -1,5 +1,4 @@
-﻿using OneOf.Types;
-using SelectParser;
+﻿using SelectParser;
 using SelectParser.Queries;
 using Utf8Json;
 using Utf8Json.Resolvers;

--- a/SelectQuery.Evaluation/SelectQuery.Evaluation.csproj
+++ b/SelectQuery.Evaluation/SelectQuery.Evaluation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <Nullable>warnings</Nullable>
 


### PR DESCRIPTION
Multiple benefits:

1. Removes dependencies, no polluting downstream projects with additional things to keep up to date
2. Performance, note in the before we're in "micro"second/"kilo"bytes and the after in "nano"seconds and bytes!

Before:
| Method | Query            | Mean         | Error       | StdDev      | Gen0    | Gen1   | Gen2   | Allocated |
|------- |----------------- |-------------:|------------:|------------:|--------:|-------:|-------:|----------:|
| **Parse**  | **aggregated**       | **43.337 μs**    | **0.9343 μs**     | **0.0512 μs**  | **3.5400**   | **-**        | **-**       | **65.94 KB**    |
| **Parse**  | **filtered**         | **39.432 μs**    | **2.1093 μs**     | **0.1156 μs**  | **3.1738**   | **-**        | **-**       | **58.43 KB**    |
| **Parse**  | **large IN filter**  | **6,628.939 μs** | **638.7559 μs**   | **35.0124 μs** | **492.1875** | **218.7500** | **-**       | **9138.3 KB**   |
| **Parse**  | **large projection** | **8,074.441 μs** | **1,208.3028 μs** | **66.2312 μs** | **796.8750** | **453.1250** | **78.1250** | **14868.81 KB** |
| **Parse**  | **projection**       | **24.915 μs**    | **8.7671 μs**     | **0.4806 μs**  | **2.0142**   | **-**        | **-**       | **37.24 KB**    |
| **Parse**  | **simple**           | **2.920 μs**     | **0.1492 μs**     | **0.0082 μs**  | **0.2785**   | **-**        | **-**       | **5.15 KB**     |

After:
| Method | Query            | Mean         | Error       | StdDev      | Gen0    | Gen1   | Allocated |
|------- |----------------- |-------------:|------------:|------------:|--------:|-------:|----------:|
| **Parse**  | **aggregated**       |   **1,928.6 ns** |    **23.09 ns** |    **21.60 ns** |  **0.0687** |      **-** |    **1320 B** |
| **Parse**  | **filtered**         |   **1,933.8 ns** |    **15.34 ns** |    **14.34 ns** |  **0.0687** |      **-** |    **1304 B** |
| **Parse**  | **large IN filter**  | **235,763.9 ns** | **1,696.13 ns** | **1,416.35 ns** |  **8.0566** | **1.9531** |  **153632 B** |
| **Parse**  | **large projection** | **303,851.2 ns** | **3,255.57 ns** | **3,045.27 ns** | **15.6250** | **5.8594** |  **296872 B** |
| **Parse**  | **projection**       |   **1,186.5 ns** |     **4.85 ns** |     **4.05 ns** |  **0.0610** |      **-** |    **1176 B** |
| **Parse**  | **simple**           |     **143.8 ns** |     **1.01 ns** |     **0.94 ns** |  **0.0114** |      **-** |     **216 B** |
